### PR TITLE
add docker and rufo

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,42 @@
+FROM ruby:3.4
+
+# Install system dependencies
+RUN apt-get update -qq && apt-get install -y \
+  build-essential \
+  libpq-dev \
+  nodejs \
+  yarn \
+  wget \
+  unzip \
+  xvfb \
+  libnss3 \
+  libatk-bridge2.0-0 \
+  libgtk-3-0 \
+  libxss1 \
+  libasound2 \
+  libgbm1 \
+  libxshmfence1 \
+  libu2f-udev \
+  libvulkan1 \
+  fonts-liberation \
+  libappindicator3-1 \
+  libnss3-tools \
+  chromium
+
+# Install ChromeDriver matching Chromium version
+RUN apt-get update && apt-get install -y \
+  chromium \
+  chromium-driver
+
+# Set working directory
+WORKDIR /app
+
+# Copy Gemfile + install gems
+COPY Gemfile* ./
+RUN bundle install
+
+# Copy rest of the app
+COPY . .
+
+# Start Rails server by default
+CMD ["bin/rails", "server", "-b", "0.0.0.0"]

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -15,3 +15,6 @@ group :development, :test do
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
 end
 
+group :development do
+  gem "rufo", "~> 0.18.1"
+end

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -117,6 +117,8 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
+    nokogiri (1.18.8-aarch64-linux-gnu)
+      racc (~> 1.4)
     nokogiri (1.18.8-x86_64-linux-gnu)
       racc (~> 1.4)
     pp (0.6.2)

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -176,6 +176,7 @@ GEM
       psych (>= 4.0.0)
     reline (0.6.1)
       io-console (~> 0.5)
+    rufo (0.18.1)
     securerandom (0.4.1)
     stringio (3.1.7)
     thor (1.3.2)
@@ -198,6 +199,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.0.2)
+  rufo (~> 0.18.1)
   tzinfo-data
 
 BUNDLED WITH

--- a/backend/README.md
+++ b/backend/README.md
@@ -6,8 +6,10 @@
 bundle install
 ```
 
-To start the rails server on port 3000:
+To start the rails server on port 3000 we'll be using a dev script that includes Docker Compose (check the [Getting Started](./_GettingStarted.md) doc for install tips).
+
+To run the dev script:
 
 ```sh
-bin/rails s -p 3000
+bin/dev
 ```

--- a/backend/_GettingStarted.md
+++ b/backend/_GettingStarted.md
@@ -74,6 +74,95 @@ gem install rails
 rails -v
 ```
 
-## VS Code
+## VSCode Ruby Support
 
 If ruby files look gross in VS Code, install the Ruby extension from Shopify.
+
+## VSCode Ruby Formatter
+
+I've added Rufo as a gem on this project and in combo with the vscode extension it can auto format on save like prettier does on the front end.
+
+You'll need to run the install command to make sure you've got it locally:
+
+```sh
+bundle install
+```
+
+In VSCode you will need to install the extension by clicking on [this link](vscode:extension/mbessey.vscode-rufo) or search for:
+
+> rufo (Ruby formatter)\
+> Matt Bessey
+
+Once gem and extension are installed: in a ruby file, open the context menu and select "Format Document With...". Configure your default formatter as rufo.
+
+## Docker
+
+Docker will be used to run the backend, so you'll need to install it (unless you have it already).
+
+To check if you have it, run:
+
+```sh
+docker -v
+```
+
+If you don't have it, you can follow the Docker install guide. I think for Mac and Windows (non WSL) you can use the [Docker Desktop](https://www.docker.com/products/docker-desktop/). But this is what I (a WSL user) did:
+
+```sh
+sudo apt-get update
+sudo apt-get install docker.io
+```
+
+Then you can create and add your user to a docker group so you can run it without using `sudo` every single time:
+
+```sh
+sudo usermod -aG docker $USER
+newgrp docker
+```
+
+You can check if it worked by running:
+
+```sh
+docker run hello-world
+```
+
+And it should show a welcome print out.
+
+## Docker Compose
+
+Docker Compose is used to run multiple containers at once, which is useful for the backend and database stuff (which we'll likely add later).
+
+Again, Mac and Windows can use the Docker Desktop app, and WSL will install it directly.
+
+I, a WSL user, followed the docker docs which talked about certificates and keyrings and stuff, but tbh you can probably just install it directly and it should be fine.
+
+To install it:
+
+```sh
+sudo apt-get install docker-compose-plugin
+```
+
+This should let us use the command `docker compose` (with a space) instead of `docker-compose` (with a hyphen).
+
+## Starting the Backend
+
+Before we can run the backend, we need to build the Docker images.
+
+To do this, within the backend directory and run:
+
+```sh
+docker compose build
+```
+
+Generally, to start our application, we will use:
+
+```sh
+docker compose up
+```
+
+Once it is running, you can access the Rails server at `http://localhost:3000`. It should update automatically as you make changes to the code, you'll just need to refresh the page.
+
+To stop the application, you can just use `Ctrl + C` but you can also go into another terminal and use:
+
+```sh
+docker compose down
+```

--- a/backend/_GettingStarted.md
+++ b/backend/_GettingStarted.md
@@ -105,7 +105,20 @@ To check if you have it, run:
 docker -v
 ```
 
-If you don't have it, you can follow the Docker install guide. I think for Mac and Windows (non WSL) you can use the [Docker Desktop](https://www.docker.com/products/docker-desktop/). But this is what I (a WSL user) did:
+If you don't have it, you can follow the official Docker install guide or follow or steps below:
+
+<details><summary>Mac & Windows (non WSL)</summary>
+
+You can use the [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+
+- Install the Docker Desktop version for you Mac device (Silicon Chip or Intel)
+- Follow set up instructions from the application (create account/sign in)
+
+</details>
+
+<details><summary>WSL</summary>
+
+Install Docker via the command line:
 
 ```sh
 sudo apt-get update
@@ -119,7 +132,9 @@ sudo usermod -aG docker $USER
 newgrp docker
 ```
 
-You can check if it worked by running:
+</details>
+
+To check it worked, run:
 
 ```sh
 docker run hello-world
@@ -131,9 +146,15 @@ And it should show a welcome print out.
 
 Docker Compose is used to run multiple containers at once, which is useful for the backend and database stuff (which we'll likely add later).
 
-Again, Mac and Windows can use the Docker Desktop app, and WSL will install it directly.
+To check if it's already installed:
 
-I, a WSL user, followed the docker docs which talked about certificates and keyrings and stuff, but tbh you can probably just install it directly and it should be fine.
+```sh
+docker compose version
+```
+
+<details><summary>WSL</summary>
+
+As a WSL user, followed the docker docs which talked about certificates and keyrings and stuff, but tbh you can probably just install it directly and it should be fine.
 
 To install it:
 
@@ -142,6 +163,32 @@ sudo apt-get install docker-compose-plugin
 ```
 
 This should let us use the command `docker compose` (with a space) instead of `docker-compose` (with a hyphen).
+
+</details>
+
+<details><summary>Mac (with Homebrew)</summary>
+
+Check you have homebrew with `brew --version` and if not present, install:
+
+```sh
+ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+Update brew formulae and cask to make sure you have the latest package versions:
+
+```sh
+brew update
+```
+
+Use brew to install Docker Compose and add it to your system:
+
+```sh
+brew install docker-compose
+```
+
+And that‘s it! With 3 quick terminal commands, Homebrew pulled down its Docker Compose formula, handled installing any dependencies, resolved conflicts with other apps, and activated the latest supported Docker Compose release.
+
+</details>
 
 ## Starting the Backend
 

--- a/backend/bin/dev
+++ b/backend/bin/dev
@@ -1,2 +1,7 @@
 #!/usr/bin/env ruby
-exec "./bin/rails", "server", *ARGV
+
+exec "docker compose up --build --remove-orphans"
+# This script is used to start the backend services using Docker Compose.
+# -d : Run containers in detached mode.
+# --build : Build images before starting containers.
+# --remove-orphans : Remove containers for services not defined in the Compose file.

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  web:
+    build: .
+    ports:
+      - '3000:3000'
+    volumes:
+      - .:/app
+    environment:
+      - RAILS_ENV=development
+    # depends_on:
+    #   - db
+#   db:
+#     image: postgres:15
+#     environment:
+#       POSTGRES_USER: postgres
+#       POSTGRES_PASSWORD: password
+#     volumes:
+#       - db-data:/var/lib/postgresql/data
+
+# volumes:
+#   db-data:


### PR DESCRIPTION
<!-- Description of task purpose -->
In prep for web scraping we need chromium. To run it easiest docker has been added, though this does require some new setup.

Rufo has also been added for automatic ruby formatting.

Project ticket: #29 

### Acceptance Criteria
- [x] Docker generates dev image using chromium
- [x] Dev script starts using docker

### Discoveries
<!-- Anything to note/for others' understanding -->

- Docker has a whole install process, so notes have been added to the Getting Started doc.
- The first time running docker to start the dev script it will take a while as it needs to build for the first time.
- Rufo needs a VSCode extension installed, also detailed in Getting Started.

### Testing
<!-- Notes on how to manual test, evidence of added tests passing with 80% coverage etc -->
To manually test, `bin/dev` should be run. Docker will run a printout followed by a message like:

 ✔ web                                      Built                                                                               0.0s
 ✔ Container backend-web-1  Recreated                                                                           0.1s
 
This means docker successfully built and will be followed by the usual startup message for port 3000. This should now be accessible and display the welcome message on [GET /](https://localhost:3000).

### Checklist
- [ ] tests passing
- [x] applied relevant labels to PR ***(`chore`/`feat`/`fix` etc)***
- [x] added screenshots/recordings ***(if applicable)***


### Screenshots/Recordings ***(optional)***
Terminal after successful docker startup:
<img width="1821" height="839" alt="Screenshot 2025-07-16 163734" src="https://github.com/user-attachments/assets/21827219-054c-47fb-8a9b-9f26c4f1948b" />
