### PR TITLE
chore: #30 - scrape NW webpage

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -30,6 +30,9 @@
 
 /public/assets
 
+# Ignore large datafiles (generated during development)
+/app/assets/data/*_actual.*
+
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -18,3 +18,5 @@ end
 group :development do
   gem "rufo", "~> 0.18.1"
 end
+
+gem "selenium-webdriver", "~> 4.34"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -178,8 +178,16 @@ GEM
       psych (>= 4.0.0)
     reline (0.6.1)
       io-console (~> 0.5)
+    rexml (3.4.1)
+    rubyzip (2.4.1)
     rufo (0.18.1)
     securerandom (0.4.1)
+    selenium-webdriver (4.34.0)
+      base64 (~> 0.2)
+      logger (~> 1.4)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     stringio (3.1.7)
     thor (1.3.2)
     timeout (0.4.3)
@@ -187,6 +195,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uri (1.0.3)
     useragent (0.16.11)
+    websocket (1.2.11)
     websocket-driver (0.8.0)
       base64
       websocket-extensions (>= 0.1.0)
@@ -202,6 +211,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 8.0.2)
   rufo (~> 0.18.1)
+  selenium-webdriver (~> 4.34)
   tzinfo-data
 
 BUNDLED WITH

--- a/backend/app/controllers/search_controller.rb
+++ b/backend/app/controllers/search_controller.rb
@@ -5,29 +5,29 @@ class SearchController < ApplicationController
   def validate_search
     source = params[:supermarket]
     unless VALID_SHOPS.include?(source)
-      render json: { error: 'Invalid supermarket source' }, status: :bad_request
+      render json: { error: "Invalid supermarket source" }, status: :bad_request
       return
     end
 
     if params[:q].blank?
-      render json: { error: 'Query parameter is required' }, status: :bad_request
+      render json: { error: "Query parameter is required" }, status: :bad_request
       return
     end
   end
-  
+
   def index
     query = params[:q]
     supermarket = params[:supermarket]
-    json_path = Rails.root.join('app', 'assets', 'data', "#{supermarket}.json")
+    json_path = Rails.root.join("app", "assets", "data", "#{supermarket}.json")
 
     if File.exist?(json_path)
       render json: {
         query: query,
         supermarket: supermarket,
-        data: JSON.parse(File.read(json_path))
+        data: JSON.parse(File.read(json_path)),
       }, status: :ok
     else
-      render json: { error: 'Not found' }, status: :not_found
+      render json: { error: "Not found" }, status: :not_found
     end
   end
 end

--- a/backend/app/controllers/search_controller.rb
+++ b/backend/app/controllers/search_controller.rb
@@ -18,6 +18,18 @@ class SearchController < ApplicationController
   def index
     query = params[:q]
     supermarket = params[:supermarket]
+
+    if supermarket == "nw"
+      url = WebScraper.get_url(supermarket, query)
+      html = WebScraper.fetch_html(url)
+
+      # Save the HTML to a temporary file for development purposes
+      # This should be removed
+      temp_html_path = Rails.root.join("app", "assets", "data", "nw_actual.html")
+      File.write(temp_html_path, html)
+      puts "-----> Saved HTML to #{temp_html_path}"
+    end
+
     json_path = Rails.root.join("app", "assets", "data", "#{supermarket}.json")
 
     if File.exist?(json_path)

--- a/backend/app/services/web_scraper.rb
+++ b/backend/app/services/web_scraper.rb
@@ -1,0 +1,60 @@
+class WebScraper
+  def self.get_url(supermarket, query)
+    case supermarket
+    when "nw"
+      "https://www.newworld.co.nz/shop/search?q=#{query}&pg=1"
+    else
+      raise ArgumentError, "Unknown supermarket: #{supermarket}"
+    end
+  end
+
+  def self.fetch_html(url)
+    driver = Selenium::WebDriver.for(:chrome, options: get_browser_options)
+
+    # Adds a script to the page to redefine the 'webdriver' property
+    # This helps avoid issues with sites that block automated browsing
+    driver.execute_cdp("Page.addScriptToEvaluateOnNewDocument", source: <<~JS)
+      Object.defineProperty(navigator, 'webdriver', {
+        get: () => undefined
+      })
+    JS
+
+    begin
+      driver.navigate.to(url)
+
+      # Wait for 2 seconds or until the page source loads the expected content
+      Selenium::WebDriver::Wait.new(timeout: 2).until do
+        driver.page_source.include?("Search results for") ||
+          driver.find_elements(id: "search").any?
+      end
+
+      driver.page_source
+    ensure
+      driver.quit
+    end
+  end
+
+  private
+
+  def self.get_browser_options
+    options = Selenium::WebDriver::Chrome::Options.new
+
+    # path for chromium on docker
+    options.binary = "/usr/bin/chromium"
+
+    # ---- Some of these may be unnecessary, but they help with performance etc --
+    options.add_argument("--headless=new") # new headless mode for compatibility
+    options.add_argument("--disable-gpu") # disable hardware acceleration
+    options.add_argument("--disable-dev-shm-usage") # fix limited resource problems in docker
+    options.add_argument("--no-sandbox") # disable the sandbox for security reasons
+    options.add_argument("--disable-blink-features=AutomationControlled") # disable automation features for stealth
+    # ----
+
+    # A common browser user agent, to avoid rejection by the site
+    options.add_argument("user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) " \
+    "AppleWebKit/537.36 (KHTML, like Gecko) " \
+    "Chrome/114.0.0.0 Safari/537.36")
+
+    options
+  end
+end


### PR DESCRIPTION
<!-- Description of task purpose -->
The first part of accessing nw product data is collecting the current HTML from the site. This involves accessing the live site, not being rejected for automation, and retrieving the html for later processing.

Project ticket: #30 

### Acceptance Criteria
- [x] When a GET request is made to /search/nw?q=QUERY, we access newworld.co.nz/shop/search?pg=1&q=QUERY
- [x] HTML is returned containing relevant products

### Discoveries
<!-- Anything to note/for others' understanding -->
More complex functionality, such as data access, is generally held within service classes. 

Rails code tends to be extracted into two types of files, helpers and services. Helpers are small reusable functions with a specific job (such as string manipulation, calculations, etc), as opposed to services which are generally for interacting with external systems or performing complex operations.

### Testing
<!-- Notes on how to manual test, evidence of added tests passing with 80% coverage etc -->
Manual testing:
- while running `bin/dev` make a request to localhost 3000 for `/search/nw?q=milk` (or any other product)
- file should be generated called `app/assets/data/nw_actual.html`
- file will contain the words `Search results for “milk”` and many instances of product names

### Checklist
- [ ] tests passing
- [x] applied relevant labels to PR ***(`chore`/`feat`/`fix` etc)***
- [ ] added screenshots/recordings ***(if applicable)***


### Screenshots/Recordings ***(optional)***
