### PR TITLE
Chore #31 - NW html to json

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -20,3 +20,5 @@ group :development do
 end
 
 gem "selenium-webdriver", "~> 4.34"
+
+gem "nokogiri", "~> 1.18"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -117,8 +117,6 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.8-aarch64-linux-gnu)
-      racc (~> 1.4)
     nokogiri (1.18.8-x86_64-linux-gnu)
       racc (~> 1.4)
     pp (0.6.2)
@@ -207,6 +205,7 @@ PLATFORMS
 
 DEPENDENCIES
   debug
+  nokogiri (~> 1.18)
   propshaft
   puma (>= 5.0)
   rails (~> 8.0.2)

--- a/backend/app/assets/data/nw.json
+++ b/backend/app/assets/data/nw.json
@@ -9,6 +9,7 @@
       "productPageUrl": "/shop/product/5023660_ea_000pns?name=pams-pure-butter",
       "price": {
         "value": "8.49",
+        "per": "ea",
         "unitPrice": "1.70",
         "unit": "100g"
       },
@@ -22,6 +23,7 @@
       "productPageUrl": "/shop/product/5002650_ea_000pns?name=anchor-butter",
       "price": {
         "value": "10.99",
+        "per": "ea",
         "unitPrice": "2.20",
         "unit": "100g"
       },
@@ -35,10 +37,18 @@
       "productPageUrl": "/shop/product/5001313_ea_000pns?name=anchor-original-soft-spreadable-dairy-blend",
       "price": {
         "value": "7.99",
+        "per": "ea",
         "unitPrice": "1.60",
         "unit": "100g"
       },
-      "promo": {}
+      "promo": {
+        "tag": "Super Saver Club Deal",
+        "value": "6.99",
+        "per": "ea",
+        "unitPrice": "1.40",
+        "unit": "100g",
+        "limit": "Limit 12 assorted"
+      }
     },
     {
       "id": "5263014",
@@ -48,16 +58,16 @@
       "productPageUrl": "/shop/product/5263014_ea_000pns?name=pams-buttery-spread",
       "price": {
         "value": "4.29",
+        "per": "ea",
         "unitPrice": "0.86",
         "unit": "100g"
       },
       "promo": {
         "tag": "Club Deal",
-        "price": {
-          "value": "3.39",
-          "unitPrice": "0.68",
-          "unit": "100g"
-        }
+        "value": "3.39",
+        "per": "ea",
+        "unitPrice": "0.68",
+        "unit": "100g"
       }
     }
   ]

--- a/backend/app/assets/data/nw.jsx
+++ b/backend/app/assets/data/nw.jsx
@@ -10,7 +10,7 @@ export function NewWorld() {
           {/* PRODUCT GRID */}
           <div>
             <div class='_1ubi26e0'>
-              {/* Product Card */}
+              {/* Product Card - No Promo */}
               <div class='_1afq4wy0' data-testid='product-5023660-EA-000'>
                 <div class='_1afq4wy1'>
                   <a
@@ -143,7 +143,7 @@ export function NewWorld() {
                 </div>
                 <div class='_1afq4wym'></div>
               </div>
-              {/* Product Card */}
+              {/* Product Card - Every Day Low Price (No Promo) */}
               <div class='_1afq4wy0' data-testid='product-5002650-EA-000'>
                 <div class='_1afq4wy1'>
                   <a
@@ -162,6 +162,23 @@ export function NewWorld() {
                       </p>
                     </div>
                   </a>
+                  <div class='_1afq4wyi'>
+                    <div class='dkmg3a1' data-testid='product-decal-4700'>
+                      <div class=''>
+                        <img
+                          alt='Badge, Everyday Low Price'
+                          loading='lazy'
+                          width='0'
+                          height='0'
+                          decoding='async'
+                          data-nimg='1'
+                          class=''
+                          style='color: transparent'
+                          src='/next/images/decals/everyday-low-price.svg'
+                        />
+                      </div>
+                    </div>
+                  </div>
                 </div>
                 <div class='_1afq4wyl'>
                   <div class='_1afq4wy8'>
@@ -276,7 +293,7 @@ export function NewWorld() {
                 </div>
                 <div class='_1afq4wym'></div>
               </div>
-              {/* Product Card */}
+              {/* Product Card - Promo With Limit */}
               <div class='_1afq4wy0' data-testid='product-5001313-EA-000'>
                 <div class='_1afq4wy1'>
                   <a
@@ -295,6 +312,72 @@ export function NewWorld() {
                       </p>
                     </div>
                   </a>
+                  <div class='_1afq4wyi'>
+                    <div class='dkmg3a1' data-testid='product-decal-5000'>
+                      <div class='dkmg3am dkmg3af'>
+                        <img
+                          alt='Badge, Super Saver Club Deal'
+                          loading='lazy'
+                          width='0'
+                          height='0'
+                          decoding='async'
+                          data-nimg='1'
+                          class='dkmg3aj'
+                          style='color: transparent'
+                          src='/next/images/decals/club-deal-multibuy-header.svg'
+                        />
+                        <div class='dkmg3a3' data-testid='decal'>
+                          <div
+                            class='_1coez4v0 dkmg3a2 dkmg3a5'
+                            data-testid='decal-price'
+                          >
+                            <p
+                              data-testid='price-dollars'
+                              class='_1coez4v1 _1h2kw9b0 _1h2kw9b4'
+                            >
+                              6.
+                            </p>
+                            <div class='_1coez4v2'>
+                              <p
+                                data-testid='price-cents'
+                                class='_1coez4v3 _1h2kw9b0 _1h2kw9b4'
+                              >
+                                99
+                              </p>
+                              <p
+                                data-testid='price-per'
+                                class='whm0tf4 _1xxz4ve8 _1xxz4vea'
+                              >
+                                ea
+                              </p>
+                            </div>
+                          </div>
+                          <p
+                            data-testid='complex-promo-unit-price'
+                            class='dkmg3a6 w6tzb39 w6tzb329'
+                          >
+                            $1.40/100g
+                          </p>
+                          <p
+                            data-testid='promo-product-limit'
+                            class='oxaxne0 w6tzb39 w6tzb329 w6tzb340 w6tzb35i'
+                          >
+                            Limit 12 assorted
+                          </p>
+                        </div>
+                      </div>
+                      <img
+                        alt='Badge footer, Super Saver Club Deal'
+                        loading='lazy'
+                        width='0'
+                        height='0'
+                        decoding='async'
+                        data-nimg='1'
+                        style='color: transparent'
+                        src='/next/images/decals/club-deal-multibuy-footer.svg'
+                      />
+                    </div>
+                  </div>
                 </div>
                 <div class='_1afq4wyl'>
                   <div class='_1afq4wy8'>
@@ -409,7 +492,7 @@ export function NewWorld() {
                 </div>
                 <div class='_1afq4wym'></div>
               </div>
-              {/* Product Card */}
+              {/* Product Card - Promo (No Limit) */}
               <div class='_1afq4wy0' data-testid='product-5263014-EA-000'>
                 <div class='_1afq4wy1'>
                   <a

--- a/backend/app/controllers/search_controller.rb
+++ b/backend/app/controllers/search_controller.rb
@@ -28,18 +28,32 @@ class SearchController < ApplicationController
       temp_html_path = Rails.root.join("app", "assets", "data", "nw_actual.html")
       File.write(temp_html_path, html)
       puts "-----> Saved HTML to #{temp_html_path}"
-    end
 
-    json_path = Rails.root.join("app", "assets", "data", "#{supermarket}.json")
+      parser = NewWorldParser.new(html)
+      products = parser.get_products
 
-    if File.exist?(json_path)
+      # To be removed in production
+      temp_json_path = Rails.root.join("app", "assets", "data", "nw_actual.json")
+      File.write(temp_json_path, products.to_json)
+
       render json: {
         query: query,
         supermarket: supermarket,
-        data: JSON.parse(File.read(json_path)),
+        source: url,
+        results: products,
       }, status: :ok
     else
-      render json: { error: "Not found" }, status: :not_found
+      json_path = Rails.root.join("app", "assets", "data", "#{supermarket}.json")
+
+      if File.exist?(json_path)
+        render json: {
+          query: query,
+          supermarket: supermarket,
+          data: JSON.parse(File.read(json_path)),
+        }, status: :ok
+      else
+        render json: { error: "Not found" }, status: :not_found
+      end
     end
   end
 end

--- a/backend/app/controllers/search_controller.rb
+++ b/backend/app/controllers/search_controller.rb
@@ -29,8 +29,7 @@ class SearchController < ApplicationController
       File.write(temp_html_path, html)
       puts "-----> Saved HTML to #{temp_html_path}"
 
-      parser = NewWorldParser.new(html)
-      products = parser.get_products
+      products = NewWorldParser.get_products(html)
 
       # To be removed in production
       temp_json_path = Rails.root.join("app", "assets", "data", "nw_actual.json")

--- a/backend/app/services/new_world_parser.rb
+++ b/backend/app/services/new_world_parser.rb
@@ -1,13 +1,11 @@
 class NewWorldParser
-  def initialize(html)
-    @doc = Nokogiri::HTML(html)
-  end
+  def self.get_products(html)
+    doc = Nokogiri::HTML(html)
 
-  def get_products
     results = []
-    puts "-----> Parsing HTML Document: #{@doc.title}"
+    puts "-----> Parsing HTML Document: #{doc.title}"
 
-    filter_menu = @doc.at_css("[data-testid='selected-refinements']")
+    filter_menu = doc.at_css("[data-testid='selected-refinements']")
     product_grid = filter_menu.next_element
     product_grid_items = product_grid.children.children
     puts "-----> Found #{product_grid_items.size} products"
@@ -33,28 +31,28 @@ class NewWorldParser
 
   private
 
-  def extract_id(node)
+  def self.extract_id(node)
     node["data-testid"][/product-(\d+)-EA-000/, 1]
   end
 
-  def extract_name(node)
+  def self.extract_name(node)
     node.at_css("[data-testid='product-title']", node)&.text&.strip
   end
 
-  def extract_amt(node)
+  def self.extract_amt(node)
     node.at_css("[data-testid='product-subtitle']", node)&.text&.strip
   end
 
-  def extract_image(node)
+  def self.extract_image(node)
     node.at_css("[data-testid='product-image']", node)&.[]("src") || ""
   end
 
-  def extract_product_page_url(node)
+  def self.extract_product_page_url(node)
     dirty_link = node.at_css("a", node)&.[]("href")
     dirty_link.split("#").first || ""
   end
 
-  def extract_price_and_promo(node)
+  def self.extract_price_and_promo(node)
     dollar_nodes = node.css("[data-testid='price-dollars']", node)
     cent_nodes = node.css("[data-testid='price-cents']", node)
     per_nodes = node.css("[data-testid='price-per']", node)
@@ -99,13 +97,13 @@ class NewWorldParser
     }
   end
 
-  def get_value(dollar_node, cent_node)
+  def self.get_value(dollar_node, cent_node)
     pretty_dollars = dollar_node.text.strip.gsub(".", "")
     pretty_cents = cent_node.text.strip
     "$#{pretty_dollars}.#{pretty_cents}"
   end
 
-  def has_promo?(node)
+  def self.has_promo?(node)
     node.at_css("[data-testid='decal']", node).present?
   end
 end

--- a/backend/app/services/new_world_parser.rb
+++ b/backend/app/services/new_world_parser.rb
@@ -63,32 +63,32 @@ class NewWorldParser
 
     # --- Promo Price ---
     if has_promo?(node)
+      promo_badge_name = node.at_css("img", node)&.[]("alt")
+      promo[:tag] = promo_badge_name.gsub("Badge, ", "")
+
       promo[:value] = get_value(dollar_nodes.first, cent_nodes.first)
       promo[:per] = per_nodes.first.text.strip
 
       promo_unit_nodes = node.css("[data-testid='complex-promo-unit-price']", node)
-      promo_unit, promo_unit_per = promo_unit_nodes.text.strip.split("/")
+      promo_unit_price, promo_unit = promo_unit_nodes.text.strip.split("/")
+      promo[:unitPrice] = promo_unit_price
       promo[:unit] = promo_unit
-      promo[:unit_per] = promo_unit_per
 
       limit_node = node.at_css("[data-testid='promo-product-limit']", node)
       if limit_node
         promo[:limit] = limit_node.text.strip
       end
-
-      promo_badge_name = node.at_css("img", node)&.[]("alt")
-      promo[:tag] = promo_badge_name.gsub("Badge, ", "")
     end
     # ---
 
     unit_nodes = node.css("[data-testid='non-promo-unit-price']", node)
-    unit, unit_per = unit_nodes.text.strip.split("/")
+    unit_price, unit = unit_nodes.text.strip.split("/")
 
     price = {
       value: get_value(dollar_nodes.last, cent_nodes.last),
       per: per_nodes.last.text.strip,
+      unitPrice: unit_price,
       unit: unit,
-      unit_per: unit_per,
     }
 
     {
@@ -100,7 +100,7 @@ class NewWorldParser
   def self.get_value(dollar_node, cent_node)
     pretty_dollars = dollar_node.text.strip.gsub(".", "")
     pretty_cents = cent_node.text.strip
-    "$#{pretty_dollars}.#{pretty_cents}"
+    "#{pretty_dollars}.#{pretty_cents}"
   end
 
   def self.has_promo?(node)

--- a/backend/app/services/new_world_parser.rb
+++ b/backend/app/services/new_world_parser.rb
@@ -1,0 +1,111 @@
+class NewWorldParser
+  def initialize(html)
+    @doc = Nokogiri::HTML(html)
+  end
+
+  def get_products
+    results = []
+    puts "-----> Parsing HTML Document: #{@doc.title}"
+
+    filter_menu = @doc.at_css("[data-testid='selected-refinements']")
+    product_grid = filter_menu.next_element
+    product_grid_items = product_grid.children.children
+    puts "-----> Found #{product_grid_items.size} products"
+
+    product_grid_items.each do |node|
+      ticketed_prices = extract_price_and_promo(node)
+
+      product = {
+        id: extract_id(node),
+        title: extract_name(node),
+        amt: extract_amt(node),
+        image: extract_image(node),
+        productPageUrl: extract_product_page_url(node),
+        price: ticketed_prices[:price],
+        promo: ticketed_prices[:promo],
+      }
+
+      results << product
+    end
+
+    results
+  end
+
+  private
+
+  def extract_id(node)
+    node["data-testid"][/product-(\d+)-EA-000/, 1]
+  end
+
+  def extract_name(node)
+    node.at_css("[data-testid='product-title']", node)&.text&.strip
+  end
+
+  def extract_amt(node)
+    node.at_css("[data-testid='product-subtitle']", node)&.text&.strip
+  end
+
+  def extract_image(node)
+    node.at_css("[data-testid='product-image']", node)&.[]("src") || ""
+  end
+
+  def extract_product_page_url(node)
+    dirty_link = node.at_css("a", node)&.[]("href")
+    dirty_link.split("#").first || ""
+  end
+
+  def extract_price_and_promo(node)
+    dollar_nodes = node.css("[data-testid='price-dollars']", node)
+    cent_nodes = node.css("[data-testid='price-cents']", node)
+    per_nodes = node.css("[data-testid='price-per']", node)
+
+    # If there is a promo, it will appear before the main price
+    # otherwise, we will leave promo as an empty hash
+    promo = {}
+
+    # --- Promo Price ---
+    if has_promo?(node)
+      promo[:value] = get_value(dollar_nodes.first, cent_nodes.first)
+      promo[:per] = per_nodes.first.text.strip
+
+      promo_unit_nodes = node.css("[data-testid='complex-promo-unit-price']", node)
+      promo_unit, promo_unit_per = promo_unit_nodes.text.strip.split("/")
+      promo[:unit] = promo_unit
+      promo[:unit_per] = promo_unit_per
+
+      limit_node = node.at_css("[data-testid='promo-product-limit']", node)
+      if limit_node
+        promo[:limit] = limit_node.text.strip
+      end
+
+      promo_badge_name = node.at_css("img", node)&.[]("alt")
+      promo[:tag] = promo_badge_name.gsub("Badge, ", "")
+    end
+    # ---
+
+    unit_nodes = node.css("[data-testid='non-promo-unit-price']", node)
+    unit, unit_per = unit_nodes.text.strip.split("/")
+
+    price = {
+      value: get_value(dollar_nodes.last, cent_nodes.last),
+      per: per_nodes.last.text.strip,
+      unit: unit,
+      unit_per: unit_per,
+    }
+
+    {
+      price: price,
+      promo: promo,
+    }
+  end
+
+  def get_value(dollar_node, cent_node)
+    pretty_dollars = dollar_node.text.strip.gsub(".", "")
+    pretty_cents = cent_node.text.strip
+    "$#{pretty_dollars}.#{pretty_cents}"
+  end
+
+  def has_promo?(node)
+    node.at_css("[data-testid='decal']", node).present?
+  end
+end

--- a/frontend/src/types/Price.types.d.ts
+++ b/frontend/src/types/Price.types.d.ts
@@ -1,5 +1,6 @@
 type Price = {
   value: string
+  per?: string
   unitPrice: string
   unit: string
 }

--- a/frontend/src/types/Promo.types.d.ts
+++ b/frontend/src/types/Promo.types.d.ts
@@ -1,4 +1,20 @@
-type Promo = {
+type Promo = NWPromo | PNSPromo | WLSPromo
+
+type NWPromo = {
   tag: string
-  price?: Price
+  value: string
+  per: string
+  unitPrice: string
+  unit: string
+  limit?: string
+}
+
+type PNSPromo = {
+  tag: string
+  value: string
+}
+
+type WLSPromo = {
+  tag: string
+  value: string
 }


### PR DESCRIPTION
<!-- Description of task purpose -->
We already have the HTML but it is now turned into JSON for the response.

As some changes were made to the data structure, this is reflected across the hard-coded data files and the front-end types.

Project ticket: #31 

### Acceptance Criteria
- [x] HTML for each product turned into an object matching the front end type, Product
- [x] search route returns data in JSON format
- [x] response data matches hard-coded files for other supermarkets

### Discoveries
<!-- Anything to note/for others' understanding -->

### Testing
<!-- Notes on how to manual test, evidence of added tests passing with 80% coverage etc -->

- while running bin/dev make a request to localhost 3000 for /search/nw?q=butter (or any other product)
- files containing live data (~50 results) should be generated called
  - `app/assets/data/nw_actual.html`
  - `app/assets/data/nw_actual.json`
- the terminal will show parser start and success messages:
```
web-1  | -----> Parsing HTML Document: Search results for "butter" | New World
web-1  | -----> Found 50 products
```
- JSON response should be displayed on browser containing ~50 products in data array with structure:
```ts
{
  query: "butter",
  supermarket: "nw",
  source: "https://www.newworld.co.nz/shop/search?q=butter&pg=1",
  results: Product[] 
}
```


### Checklist
- [ ] tests passing
- [x] applied relevant labels to PR ***(`chore`/`feat`/`fix` etc)***
- [ ] added screenshots/recordings ***(if applicable)***


### Screenshots/Recordings ***(optional)***
