### PR TITLE
chore: #39 woolworths web scrape

### DIFF
--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -119,6 +119,8 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
+    nokogiri (1.18.8-aarch64-linux-gnu)
+      racc (~> 1.4)
     nokogiri (1.18.8-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.8-x86_64-linux-gnu)
@@ -222,6 +224,7 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-24
   x86_64-linux-gnu
 

--- a/backend/app/controllers/search_controller.rb
+++ b/backend/app/controllers/search_controller.rb
@@ -18,7 +18,7 @@ class SearchController < ApplicationController
     puts "---> Searching for '#{query}' in #{supermarket} supermarket"
 
     # TO BE REMOVED: once all scrapers working, we should check against VALID_SHOPS instead
-    temp_supermarkets = %w[nw pns]
+    temp_supermarkets = %w[nw pns wls putYoursHere]
 
     if temp_supermarkets.include?(supermarket)
       begin
@@ -32,6 +32,10 @@ class SearchController < ApplicationController
         parser = case supermarket
           when "nw"
             NewWorldParser
+
+          # when "wls"
+          #   WoolworthsParser
+
           end
 
         products = parser.get_products(html)

--- a/backend/app/services/web_scraper.rb
+++ b/backend/app/services/web_scraper.rb
@@ -11,6 +11,8 @@ class WebScraper
       "https://www.newworld.co.nz/shop/search?q=#{query}&pg=1"
     when "pns"
       "https://www.paknsave.co.nz/shop/search?pg=1&q=#{query}"
+    when "wls"
+      "https://www.woolworths.co.nz/shop/searchproducts?search=#{query}"
     else
       raise ArgumentError, "Unknown supermarket: #{supermarket}"
     end

--- a/frontend/src/components/Card/Card.tsx
+++ b/frontend/src/components/Card/Card.tsx
@@ -1,4 +1,5 @@
 import { RUICard } from "@/components/retroui";
+
 import { CardDetails } from "../CardDetails";
 
 export type ProductProps = {

--- a/frontend/src/components/CardDetails/CardDetails.test.tsx
+++ b/frontend/src/components/CardDetails/CardDetails.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
 import { describe, expect, it } from "vitest";
 import { axe } from "vitest-axe";
-import { MemoryRouter } from "react-router";
 
 import { CardDetails } from "./CardDetails";
 
@@ -10,7 +10,11 @@ describe("Given a user is looking at an individual product's details", () => {
     it("Then store, product name and price is displayed", () => {
       render(
         <MemoryRouter initialEntries={["/"]}>
-          <CardDetails productTitle="Pams Butter" price="3.50" store="Woolworths" />
+          <CardDetails
+            productTitle="Pams Butter"
+            price="3.50"
+            store="Woolworths"
+          />
         </MemoryRouter>,
       );
       expect(screen.getByText(/pams butter/i)).toBeInTheDocument();
@@ -20,7 +24,11 @@ describe("Given a user is looking at an individual product's details", () => {
       it("The product name and price is displayed", () => {
         render(
           <MemoryRouter initialEntries={["/browse"]}>
-            <CardDetails productTitle="Pams Butter" price="3.50" store="Woolworths" />
+            <CardDetails
+              productTitle="Pams Butter"
+              price="3.50"
+              store="Woolworths"
+            />
           </MemoryRouter>,
         );
         expect(screen.queryByText(/woolworths/i)).not.toBeInTheDocument();
@@ -31,7 +39,12 @@ describe("Given a user is looking at an individual product's details", () => {
       it("Then it has no accessibility violations", async () => {
         const { container } = render(
           <MemoryRouter initialEntries={["/"]}>
-            <CardDetails productTitle="Pams Butter" price="3.50" store="Woolworths" />,
+            <CardDetails
+              productTitle="Pams Butter"
+              price="3.50"
+              store="Woolworths"
+            />
+            ,
           </MemoryRouter>,
         );
         const results = await axe(container);

--- a/frontend/src/components/CardDetails/CardDetails.tsx
+++ b/frontend/src/components/CardDetails/CardDetails.tsx
@@ -1,7 +1,9 @@
-import { RUICard, Button } from "@/components/retroui";
-import { toast } from "sonner";
-import type { ProductProps } from "../Card/Card";
 import { useLocation } from "react-router";
+import { toast } from "sonner";
+
+import { Button, RUICard } from "@/components/retroui";
+
+import type { ProductProps } from "../Card/Card";
 
 // TODO /browse comp needs styling once in the browse grid
 


### PR DESCRIPTION
Create web scraper for Woolworths supermarket. It returns the html for search request and saves that to the `wls_actual.html` file.

Includes file changes to fix linting issues. 

Project ticket: #39 

### Acceptance Criteria
- [x] When a GET request is made to /search/wls?q=QUERY, we access woolworths.co.nz/shop/searchproducts?search=QUERY
- [x] HTML is returned containing relevant products

### Discoveries
<!-- Anything to note/for others' understanding -->

### Testing
<!-- Notes on how to manual test, evidence of added tests passing with 80% coverage etc -->
- Run `bin/dev` 
- Have docker up and running
- Go to localhost 
- Search with `http://localhost:3000/search/wls?q=butter` or whatever product you'd like to search
- See the same/similar output to what is attached in screenshots


### Checklist
- [ ] tests passing
- [x] applied relevant labels to PR ***(`chore`/`feat`/`fix` etc)***
- [x] added screenshots/recordings ***(if applicable)***


### Screenshots/Recordings ***(optional)***

<img width="1167" height="270" alt="Screenshot 2025-07-24 at 2 11 46 PM" src="https://github.com/user-attachments/assets/aec1e857-4fe5-4724-b353-4f86e89735fd" />

<img width="225" height="244" alt="Screenshot 2025-07-24 at 2 11 22 PM" src="https://github.com/user-attachments/assets/540b125d-f35a-4cfe-b08f-c54ee3d83c5a" />

