### PR TITLE
rewrite rb comments to match style

### DIFF
--- a/backend/app/controllers/search_controller.rb
+++ b/backend/app/controllers/search_controller.rb
@@ -1,16 +1,16 @@
 class SearchController < ApplicationController
   VALID_SHOPS = %w[nw pns wls test_shop]
-  before_action :validate_search
+  before_action :validate_search!
 
-  # Handles the search request for products in a specified supermarket.
+  # search#index - Handles the search request for products from a specified supermarket
   #
-  # @param q [String] The search query.
-  # @param supermarket [String] The supermarket identifier.
-  # @return [JSON] The search results in JSON format.
-  #   - query: The search query.
-  #   - supermarket: The supermarket identifier.
-  #   - source: The URL of the search results.
-  #   - results: An array of products found in the search.
+  # @param q [String] The product search query
+  # @param supermarket [String] The supermarket identifier
+  # @return [JSON] The search results
+  #   - query: The search query
+  #   - supermarket: The supermarket identifier
+  #   - source: The URL of the supermarket search
+  #   - results: The array of products found
   def index
     query = params[:q]
     supermarket = params[:supermarket]
@@ -61,10 +61,10 @@ class SearchController < ApplicationController
 
   private
 
-  # Validates the search parameters.
+  # validate_search! - Responds with an error if the supermarket or query is invalid
   #
-  # @raise [ActionController::BadRequest] If the supermarket is invalid or the query is blank.
-  def validate_search
+  # @raise [ActionController::BadRequest] If the supermarket is not in the list of valid shops or if the query parameter is blank
+  def validate_search!
     source = params[:supermarket]
     unless VALID_SHOPS.include?(source)
       render json: { error: "Invalid supermarket source" }, status: :bad_request

--- a/backend/app/services/data_manager.rb
+++ b/backend/app/services/data_manager.rb
@@ -1,12 +1,12 @@
 class DataManager
   VALID_SUPERMARKETS = %w[nw pns wls]
 
-  # Reads the HTML file for the specified supermarket.
+  # read_json_file - Reads the JSON file for the specified supermarket
   #
-  # @param supermarket [String] The supermarket identifier.
-  # @return [JSON || nil] The JSON content or nil if the file does not exist.
+  # @param supermarket [String] The supermarket identifier
+  # @return [JSON || nil] The JSON content or nil if the file does not exist
   def self.read_json_file(supermarket)
-    validate_supermarket!(supermarket) # <= ! for DANGER
+    validate_supermarket!(supermarket)
     json_path = Rails.root.join("app", "assets", "data", "#{supermarket}.json")
 
     File.exist?(json_path) ? File.read(json_path) : nil
@@ -15,10 +15,10 @@ class DataManager
     nil
   end
 
-  # Writes the HTML content to a file for the specified supermarket.
+  # write_html_file - Writes HTML to a file for the specific supermarket
   #
-  # @param supermarket [String] The supermarket identifier.
-  # @param data [String] The HTML content to write.
+  # @param supermarket [String] The supermarket identifier
+  # @param data [String] The HTML content to write
   def self.write_html_file(supermarket, data)
     if Rails.env.development?
       validate_supermarket!(supermarket)
@@ -31,13 +31,14 @@ class DataManager
     warn "Error writing HTML file: #{e.message}"
   end
 
-  # Writes the JSON data to a file for the specified supermarket.
+  # write_json_file - Writes JSON data to a file for the specific supermarket
   #
-  # @param supermarket [String] The supermarket identifier.
-  # @param data [Hash] The data to write as JSON.
+  # @param supermarket [String] The supermarket identifier
+  # @param data [Hash] The data to write
   def self.write_json_file(supermarket, data)
     if Rails.env.development?
       validate_supermarket!(supermarket)
+
       json_path = Rails.root.join("app", "assets", "data", "#{supermarket}_actual.json")
 
       File.write(json_path, JSON.pretty_generate(data))
@@ -49,10 +50,10 @@ class DataManager
 
   private
 
-  # Validates the supermarket identifier.
+  # validate_supermarket! - Checks that the supermarket is recognized
   #
-  # @param supermarket [String] The supermarket identifier.
-  # @raise [ArgumentError] If the supermarket is not recognized.
+  # @param supermarket [String] The supermarket identifier
+  # @raise [ArgumentError] If the supermarket is not recognized
   def self.validate_supermarket!(supermarket)
     unless VALID_SUPERMARKETS.include?(supermarket)
       raise ArgumentError, "Unknown supermarket: #{supermarket}"

--- a/backend/app/services/new_world_parser.rb
+++ b/backend/app/services/new_world_parser.rb
@@ -1,9 +1,9 @@
 class NewWorldParser
 
-  # Parses the HTML content of a New World product page to extract product details.
+  # get_products - Parses HTML to extract product details
   #
-  # @param html [String] The HTML content of the product page.
-  # @return [Array<Product>] An array of hashes containing product details.
+  # @param html [String] The HTML from a product page
+  # @return [Array<Product>] A list of products
   def self.get_products(html)
     doc = Nokogiri::HTML(html)
     puts "-----> Parsing HTML Document: #{doc.title}"
@@ -28,10 +28,10 @@ class NewWorldParser
 
   private
 
-  # Parses a single product node to extract its details.
+  # parse_one_product - Extracts details for a single product
   #
-  # @param node [Nokogiri::XML::Element] The product node to parse.
-  # @return [Product || nil] A hash containing the product details or nil if parsing fails.
+  # @param node [Nokogiri::XML::Element] The parent tag containing product details
+  # @return [Product || nil] The product details or nil if parsing fails
   def self.parse_one_product(node)
     ticketed_prices = extract_price_and_promo(node)
 
@@ -49,62 +49,61 @@ class NewWorldParser
     nil
   end
 
-  # Extracts the product ID from the node.
+  # extract_id - Retrieves the product ID
   #
-  # @param node [Nokogiri::XML::Element] The product node.
-  # @return [String] The product ID.
+  # @param node [Nokogiri::XML::Element] The product node
+  # @return [String] The product ID
   def self.extract_id(node)
     node["data-testid"][/product-(\d+)-EA-000/, 1]
   end
 
-  # Extracts the product name from the node.
+  # extract_name - Retrieves the product name
   #
-  # @param node [Nokogiri::XML::Element] The product node.
-  # @return [String] The product name.
+  # @param node [Nokogiri::XML::Element] The product node
+  # @return [String] The product name
   def self.extract_name(node)
     node.at_css("[data-testid='product-title']", node)&.text&.strip
   end
 
-  # Extracts the amount from the node.
+  # extract_amt - Retrieves the amount (weight, volume) of the product
   #
-  # @param node [Nokogiri::XML::Element] The product node.
-  # @return [String] The amount (weight, volume) of the product.
+  # @param node [Nokogiri::XML::Element] The product node
+  # @return [String] The total product amount
   def self.extract_amt(node)
     node.at_css("[data-testid='product-subtitle']", node)&.text&.strip
   end
 
-  # Extracts the product image URL from the node.
+  # extract_image - Retrieves the product image URL
   #
-  # @param node [Nokogiri::XML::Element] The product node.
-  # @return [String] The product image URL.
+  # @param node [Nokogiri::XML::Element] The product node
+  # @return [String] The product image URL
   def self.extract_image(node)
     node.at_css("[data-testid='product-image']", node)&.[]("src")
   end
 
-  # Extracts the product page URL from the node.
+  # extract_product_page_url - Retrieves the page URL for the individual product
   #
-  # @param node [Nokogiri::XML::Element] The product node.
-  # @return [String] The product page URL.
-  #
+  # @param node [Nokogiri::XML::Element] The product node
+  # @return [String] The product page URL
   def self.extract_product_page_url(node)
     dirty_link = node.at_css("a", node)&.[]("href")
     dirty_link.split("#").first
   end
 
-  # Extracts the price and promotional details from the product node.
+  # extract_price_and_promo - Retrieves the price and promo details
   #
-  # @param node [Nokogiri::XML::Element] The product node.
-  # @return [Hash] A hash containing the price and promotional details.
+  # @param node [Nokogiri::XML::Element] The product node
+  # @return [Hash] The price and promo details
   #   - :price [Hash] :value, :per, :unitPrice, :unit
-  #   - :promo [Hash] :value, :per, :unitPrice, :unit, :tag, and optionally :limit.
+  #   - :promo [Hash] :value, :per, :unitPrice, :unit, :tag, :limit?
   def self.extract_price_and_promo(node)
     dollar_nodes = node.css("[data-testid='price-dollars']", node)
     cent_nodes = node.css("[data-testid='price-cents']", node)
     per_nodes = node.css("[data-testid='price-per']", node)
 
+    promo = {}
     # If there is a promo, it will appear before the main price
     # otherwise, we will leave promo as an empty hash
-    promo = {}
 
     # --- Promo Price ---
     if has_promo?(node)
@@ -142,23 +141,25 @@ class NewWorldParser
     }
   end
 
-  # Formats the price value from dollar and cent nodes.
+  # get_value - returns the price as a standardized string, "dollars.cents"
   #
-  # @param dollar_node [Nokogiri::XML::Element] Node containing the dollar price.
-  # @param cent_node [Nokogiri::XML::Element] Node containing the cent price.
-  # @return [String] The formatted price value as a string.
+  # @param dollar_node [Nokogiri::XML::Element] Node containing the dollars
+  # @param cent_node [Nokogiri::XML::Element] Node containing the cents
+  # @return [String] The formatted price
   #
-  # Example: get_value(<p>3.</p>, <p>12</p>) => "3.12"
+  # @example
+  #   get_value(<p> 3 </p>, <p> 12 </p>) => "3.12"
+  #   get_value(<p> 3. </p>, <p> 12 </p>) => "3.12"
   def self.get_value(dollar_node, cent_node)
     pretty_dollars = dollar_node.text.strip.gsub(".", "")
     pretty_cents = cent_node.text.strip
     "#{pretty_dollars}.#{pretty_cents}"
   end
 
-  # Checks if the product node has a promotional decal.
+  # has_promo? - Checks if the product has a promo
   #
-  # @param node [Nokogiri::XML::Element] The product node.
-  # @return [Boolean] TRUE if the product has a promo decal, FALSE otherwise.
+  # @param node [Nokogiri::XML::Element] The product node
+  # @return [Boolean] TRUE if a promo decal is present
   def self.has_promo?(node)
     node.at_css("[data-testid='decal']", node).present?
   end

--- a/backend/app/services/web_scraper.rb
+++ b/backend/app/services/web_scraper.rb
@@ -1,10 +1,10 @@
 class WebScraper
 
-  # Generates a URL for the specified supermarket and query.
+  # get_url - Generates the search URL for the specified supermarket
   #
-  # @param supermarket [String] The name of the supermarket (e.g., "nw").
-  # @param query [String] The search query to append to the URL.
-  # @return [String] The generated URL for the supermarket search.
+  # @param supermarket [String] The supermarket identifier (e.g., "nw")
+  # @param query [String] The search query
+  # @return [String] The URL for the supermarket search
   def self.get_url(supermarket, query)
     case supermarket
     when "nw"
@@ -14,10 +14,10 @@ class WebScraper
     end
   end
 
-  # Fetches the HTML content of the specified URL using Selenium WebDriver.
+  # fetch_html - Fetches the HTML from a given URL
   #
-  # @param url [String] The URL to fetch.
-  # @return [String] The HTML content of the page.
+  # @param url [String] The URL to fetch
+  # @return [String] The HTML content of the page
   def self.fetch_html(url)
     driver = get_webdriver
 
@@ -52,9 +52,9 @@ class WebScraper
 
   private
 
-  # Initializes a Selenium WebDriver instance with Chrome options.
+  # get_webdriver - Initializes the Selenium WebDriver with Chrome options
   #
-  # @return [Selenium::WebDriver] The initialized WebDriver instance.
+  # @return [Selenium::WebDriver] The initialized WebDriver instance
   def self.get_webdriver
     Selenium::WebDriver.for(:chrome, options: get_browser_options)
   rescue Selenium::WebDriver::Error::WebDriverError => e
@@ -63,9 +63,9 @@ class WebScraper
     raise "An error occurred while initializing WebDriver: #{e.message}"
   end
 
-  # Returns the browser options for the Selenium WebDriver.
+  # get_browser_options - Provides the configured browser options
   #
-  # @return [Selenium::WebDriver::Chrome::Options] The configured browser options.
+  # @return [Selenium::WebDriver::Chrome::Options] The browser options
   def self.get_browser_options
     options = Selenium::WebDriver::Chrome::Options.new
 

--- a/doc/readme/YARD-comments.md
+++ b/doc/readme/YARD-comments.md
@@ -19,13 +19,17 @@ We will use the basic structure of YARD comments in our codebase, with adaptatio
 
 - Descriptions should be short and non-technical, focusing on what the method does rather than how it does it.
 
-- If multiple types are possible, you can use the `||` operator to indicate this - e.g. `@return [String || nil]` for a method that returns nil sometimes, but is expected to return a String usually (String goes first).
-
 - If a pre-defined frontend type is returned, use that type instead of the raw Hash structure.
 
 - Generally, if a Hash object is returned, document the keys.
 
 - If an Array is returned, document the type of the items in the array.
+
+- If multiple types are possible, you can use the `||` operator to indicate this - e.g. `@return [String || nil]` is expected to return a String (so String goes first), but sometimes returns nil.
+
+- If a param or return value (etc) is optional, use `?` at the end of the key - e.g. `@param name? [String]` or `@return [Hash] :id, :name?` to indicate that `:name` is optional.
+
+- If a Boolean is returned, describe what the boolean means, prioritising clarity, i.e. `@return [Boolean] TRUE if the user has a name`.
 
 - If a methods _purpose_ is to raise an exception, document this using `@raise`. It is not necessary to include this tag for side effects of the method as most methods will raise some exceptions in our code.
 
@@ -88,11 +92,41 @@ def fetch_products
 end
 ```
 
-### Hash, with more complex structure
+### Booleans
+
+The description tells us what the boolean means in context, and prioritises what information this gives us rather then describing both true and false.
+
+In this example the method checks multiple things, so the boolean is only TRUE if all conditions are met. This is why we show TRUE in our `@return` tag rather than both TRUE and FALSE.
+
+```ruby
+# on_sale? - Checks if the product is considered on sale
+#
+# @param product [Product] The product to check
+# @return [Boolean] TRUE if the sale is currently available
+def on_sale?(product)
+  if product[:quantity] == 0
+    false
+  elsif product[:promo].nil?
+    false
+  end
+
+  promo_details = product[:promo]
+
+  if promo_details[:discount].nil? || promo_details[:sale_expires].nil?
+    return false
+  end
+
+  promo_details[:sale_expires] > Time.now
+end
+```
+
+### Hash, complex structure
 
 In this example we have a more complex structure, so we document the keys in the Hash to make it clear what each key represents.
 
 Depending on the complexity of the structure, you may want to break it down further or provide more detail, but this is a good starting point as more complex structures are likely predefined types.
+
+This example also shows optional keys, indicated by the `?` at the end of the key names.
 
 ```ruby
 # fetch_product - Retrieves product details from the database
@@ -102,8 +136,9 @@ Depending on the complexity of the structure, you may want to break it down furt
 #   :id [Integer] The ID of the product
 #   :title [String] The product name
 #   :categories [Array<String>] The categories the product belongs to
-#   :price [Hash] :amount, :currency, :onSale
+#   :price [Hash] :amount, :currency, :onSale, :saleExpires
 #   :stock [Hash] :available, :quantity
+#   :amount? [Float] The amount of the product
 def fetch_product(product_id)
   {
     id: product_id,
@@ -112,35 +147,13 @@ def fetch_product(product_id)
     price: {
       amount: 19.99,
       currency: "USD",
-      onSale: false
+      onSale: false,
+      saleExpires: "2030-12-31"
     },
     stock: {
       available: true,
       quantity: 100
     },
-  }
-end
-```
-
-### Multiple parameters and return types
-
-```ruby
-# calculate_discount - Works out the discount details for a product
-#
-# @param price [Float] The original price
-# @param discount_rate [Float] The discount rate as a percentage (0-100)
-# @return [Hash] Discount details
-#   :original_price [Float] Starting price before discount
-#   :discount_amount [Float] Amount removed from the original price
-#   :final_price [Float] Price after applying the discount
-def calculate_discount(price, discount_rate)
-  discount_amount = price * (discount_rate / 100.0)
-  final_price = price - discount_amount
-
-  {
-    original_price: price,
-    discount_amount: discount_amount,
-    final_price: final_price
   }
 end
 ```
@@ -165,6 +178,10 @@ end
 
 ### Example with @example
 
+Because sometimes it's easier to see how a method is used rather than just reading about it.
+
+Useful if specific inputs are needed, or if the way it is used is not obvious.
+
 ```ruby
 # format_date - Turns a date into a human-readable string
 #
@@ -175,5 +192,25 @@ end
 #   format_date(Date.new(2023, 10, 5)) => "2023-10-05"
 def format_date(date)
   date.strftime("%Y-%m-%d")
+end
+
+# get_modifier_function - Given a key, returns a func to modify a value respectively
+#
+# @param key [Symbol] The key to determine the modifier function
+# @return [Proc] A function that takes a value and returns the modified value
+#
+# @example
+#   modifier = get_modifier_function(:double)
+#   modifier.call(5) => 10
+#   modifier.call(3) => 6
+def get_modifier_function(key)
+  case key
+  when :double
+    Proc.new { |value| value * 2 }
+  when :square
+    Proc.new { |value| value ** 2 }
+  else
+    Proc.new { |value| value }
+  end
 end
 ```


### PR DESCRIPTION
<!-- Description of task purpose -->
Post establishing the ruby comment style guide, existing comments needed to be checked and updated.

A few documented examples were added during this too.

Project ticket: #87 

### Acceptance Criteria
- [x] SearchController comments updated to match style
- [x] DataManager comments updated to match style
- [x] NewWorldParser comments updated to match style
- [x] WebScraper comments updated to match style
- [x] any other ruby comments found and updated to match style

### Discoveries
<!-- Anything to note/for others' understanding -->

### Testing
<!-- Notes on how to manual test, evidence of added tests passing with 80% coverage etc -->

### Checklist
- [ ] tests passing
- [x] applied relevant labels to PR ***(`chore`/`feat`/`fix` etc)***
- [ ] added screenshots/recordings ***(if applicable)***


### Screenshots/Recordings ***(optional)***
