### PR TITLE
create stand in initialCart

### DIFF
--- a/frontend/src/context/CartContext.tsx
+++ b/frontend/src/context/CartContext.tsx
@@ -2,6 +2,8 @@ import { createContext, type ReactNode, useContext, useState } from "react";
 
 import type { Cart } from "@/types/Cart.types";
 
+import { initialCart } from "./utils/initialCart";
+
 type CartContextType = {
   cart: Cart;
   clearCart: () => void;
@@ -10,7 +12,7 @@ type CartContextType = {
 const CartContext = createContext<CartContextType | undefined>(undefined);
 
 export const CartProvider = ({ children }: { children: ReactNode }) => {
-  const [cart, setCart] = useState({ nw: [], pns: [], wls: [] });
+  const [cart, setCart] = useState(initialCart);
 
   const clearCart = () => {
     setCart({ nw: [], pns: [], wls: [] });

--- a/frontend/src/context/utils/initialCart.ts
+++ b/frontend/src/context/utils/initialCart.ts
@@ -1,0 +1,367 @@
+import type { Cart } from "@/types/Cart.types";
+
+// TODO: This (temporary) cart does not match current Cart type
+// `as Cart` is used to satisfy type checking, but replace with:
+// export const initialCart: Cart = {
+// once Parsing types from backend are finalised.
+
+export const initialCart = {
+  nw: [
+    {
+      id: "5263014",
+      quantity: 2,
+      product: {
+        id: "5263014",
+        title: "Pams Buttery Spread",
+        amt: "500g",
+        image:
+          "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5263014.png?w=384",
+        productPageUrl:
+          "/shop/product/5263014_ea_000nw?name=pams-buttery-spread",
+        price: {
+          value: "4.29",
+          per: "ea",
+          unitPrice: "0.86",
+          unit: "100g",
+        },
+        promo: {
+          tag: "",
+          value: "3.39",
+          per: "ea",
+          unitPrice: "0.68",
+          unit: "100g",
+        },
+      },
+    },
+    {
+      id: "5023660",
+      quantity: 5,
+      product: {
+        id: "5023660",
+        title: "Pams Pure Butter",
+        amt: "500g",
+        image:
+          "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5023660.png?w=384",
+        productPageUrl: "/shop/product/5023660_ea_000nw?name=pams-pure-butter",
+        price: {
+          value: "8.49",
+          per: "ea",
+          unitPrice: "1.70",
+          unit: "100g",
+        },
+        promo: {},
+      },
+    },
+    {
+      id: "5007494",
+      quantity: 1,
+      product: {
+        id: "5007494",
+        title: "V Blue Guarana Energy Drink",
+        amt: "500ml",
+        image:
+          "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5007494.png?w=384",
+        productPageUrl:
+          "/shop/product/5007494_ea_000nw?name=v-blue-guarana-energy-drink",
+        price: {
+          value: "4.19",
+          per: "ea",
+          unitPrice: "8.38",
+          unit: "1L",
+        },
+        promo: {
+          tag: "",
+          value: "5.00",
+          per: "ea",
+          unitPrice: "5.00",
+          unit: "1L",
+          limit: "Limit 12 assorted",
+        },
+      },
+    },
+    {
+      id: "5201479",
+      quantity: 40,
+      product: {
+        id: "5201479",
+        title: "Pams Value Standard Milk",
+        amt: "2l",
+        image:
+          "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5201479.png?w=384",
+        productPageUrl:
+          "/shop/product/5201479_ea_000nw?name=pams-value-standard-milk",
+        price: {
+          value: "4.60",
+          per: "ea",
+          unitPrice: "2.30",
+          unit: "1L",
+        },
+        promo: {},
+      },
+    },
+  ],
+  pns: [
+    {
+      id: "5002650",
+      quantity: 2,
+      product: {
+        id: "5002650",
+        title: "Anchor Butter",
+        amt: "500g",
+        image:
+          "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5002650.png?w=384",
+        productPageUrl: "/shop/product/5002650_ea_000nw?name=anchor-butter",
+        price: {
+          value: "10.99",
+          per: "ea",
+          unitPrice: "2.20",
+          unit: "100g",
+        },
+        promo: {
+          tag: "Club Deal",
+          value: "9.89",
+          per: "ea",
+          unitPrice: "1.98",
+          unit: "100g",
+        },
+      },
+    },
+
+    {
+      id: "5109655",
+      quantity: 12,
+      product: {
+        id: "5109655",
+        title: "Mogu Mogu Lychee Juice With Nate De Coco",
+        amt: "320ml",
+        image:
+          "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5109655.png?w=384",
+        productPageUrl:
+          "/shop/product/5109655_ea_000pns?name=mogu-mogu-lychee-juice-with-nate-de-coco",
+        price: {
+          value: "1.89",
+          per: "ea",
+          unitPrice: "5.91",
+          unit: "1L",
+        },
+        promo: {
+          tag: "Extra Low",
+          value: "5.00",
+          unitPrice: "3.91",
+          unit: "1L",
+          multibuyThreshold: "4",
+        },
+      },
+    },
+
+    {
+      id: "5294382",
+      quantity: 1,
+      product: {
+        id: "5294382",
+        title: "SB Frozen Whole Florets Broccoli",
+        amt: "1kg",
+        image:
+          "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5294382.png?w=384",
+        productPageUrl:
+          "/shop/product/5294382_ea_000pns?name=sb-frozen-whole-florets-broccoli",
+        price: {
+          value: "5.49",
+          per: "ea",
+          unitPrice: "5.49",
+          unit: "1kg",
+        },
+        promo: {},
+      },
+    },
+
+    {
+      id: "5012239",
+      quantity: 4,
+      product: {
+        id: "5012239",
+        title: "Wattie's Broccoli & Cauliflower Medley",
+        amt: "650g",
+        image:
+          "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5012239.png?w=384",
+        productPageUrl:
+          "/shop/product/5012239_ea_000pns?name=wattie%27s-broccoli--cauliflower-medley",
+        price: {
+          value: "4.59",
+          per: "ea",
+          unitPrice: "7.06",
+          unit: "1kg",
+        },
+        promo: {
+          tag: "Extra Low",
+        },
+      },
+    },
+
+    {
+      id: "5306376",
+      quantity: 1,
+      product: {
+        id: "5306376",
+        title: "Coca-Cola Zero Sugar Soft Drinks Cans",
+        amt: "8 x 330ml",
+        image:
+          "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5306376.png?w=384",
+        productPageUrl:
+          "/shop/product/5306376_ea_000pns?name=sugar-soft-drinks-cans",
+        price: {
+          value: "8.49",
+          per: "ea",
+          unitPrice: "3.22",
+          unit: "1L",
+        },
+        promo: {
+          tag: "Extra Low",
+        },
+      },
+    },
+  ],
+  wls: [
+    {
+      id: "6030021",
+      quantity: 2,
+      product: {
+        id: "6030021",
+        title: "riley coffee beans heyday 500g",
+        amt: "500g",
+        image:
+          "https://assets.woolworths.com.au/images/2010/6030021.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
+        productPageUrl:
+          "https://www.woolworths.co.nz/shop/productdetails?stockcode=6030021&name=riley-coffee-beans-heyday",
+        price: {
+          value: "25.00",
+          per: "ea",
+          unitPrice: "4.50",
+          unit: "100g",
+        },
+        promo: {
+          tag: "Special",
+          value: "22.50",
+          per: "ea",
+          unitPrice: null,
+          unit: null,
+        },
+      },
+    },
+    {
+      id: "956132",
+      quantity: 10,
+      product: {
+        id: "956132",
+        title: "whittakers chocolate block raspberry & NZ strawberry 100g",
+        amt: "100g",
+        image:
+          "https://assets.woolworths.com.au/images/2010/956132.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
+        productPageUrl:
+          "https://www.woolworths.co.nz/shop/productdetails?stockcode=956132&name=whittakers-chocolate-block-raspberry-nz-strawberry",
+        price: {
+          value: "5.99",
+          per: "ea",
+          unitPrice: "4.70",
+          unit: "100g",
+        },
+        promo: {
+          tag: "Special",
+          value: "4.70",
+          per: "ea",
+          unitPrice: null,
+          unit: null,
+        },
+      },
+    },
+    {
+      id: "253877",
+      quantity: 1,
+      product: {
+        id: "253877",
+        title: "macro eggs free range mixed grade Carton 12pack",
+        amt: null,
+        image:
+          "https://assets.woolworths.com.au/images/2010/253877.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
+        productPageUrl:
+          "https://www.woolworths.co.nz/shop/productdetails?stockcode=253877&name=macro-eggs-free-range-mixed-grade",
+        price: {
+          value: "11.20",
+          per: "ea",
+          unitPrice: "0.93",
+          unit: "1ea",
+        },
+        promo: {
+          tag: "LOW PRICE",
+        },
+      },
+    },
+    {
+      id: "281809",
+      quantity: 5,
+      product: {
+        id: "281809",
+        title: "woolworths cheese edam Block 1kg",
+        amt: "1kg",
+        image:
+          "https://assets.woolworths.com.au/images/2010/281809.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
+        productPageUrl:
+          "https://www.woolworths.co.nz/shop/productdetails?stockcode=281809&name=woolworths-cheese-edam",
+        price: {
+          value: "13.29",
+          per: "ea",
+          unitPrice: "1.33",
+          unit: "100g",
+        },
+        promo: {},
+      },
+    },
+    {
+      id: "266023",
+      quantity: 1,
+      product: {
+        id: "266023",
+        title: "watties spaghetti in tomato sauce Cans 3pack",
+        amt: null,
+        image:
+          "https://assets.woolworths.com.au/images/2010/266023.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
+        productPageUrl:
+          "https://www.woolworths.co.nz/shop/productdetails?stockcode=266023&name=watties-spaghetti-in-tomato-sauce",
+        price: {
+          value: "6.89",
+          per: "ea",
+          unitPrice: "0.55",
+          unit: "100g",
+        },
+        promo: {
+          tag: "Disney Discs Bonus Products.",
+        },
+      },
+    },
+    {
+      id: "74613",
+      quantity: 1,
+      product: {
+        id: "74613",
+        title: "la molisana pasta spaghetti 500g",
+        amt: "500g",
+        image:
+          "https://assets.woolworths.com.au/images/2010/74613.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
+        productPageUrl:
+          "https://www.woolworths.co.nz/shop/productdetails?stockcode=74613&name=la-molisana-pasta-spaghetti",
+        price: {
+          value: "3.50",
+          per: "ea",
+          unitPrice: "0.70",
+          unit: "100g",
+        },
+        promo: {
+          tag: "Special",
+          value: "2 for $5.00",
+          unitPrice: "0.50",
+          unit: "100g",
+        },
+      },
+    },
+  ],
+} as Cart;


### PR DESCRIPTION
<!-- Description of task purpose -->
Adding some (temporary) stand-in cart data to assist front-end development

Project ticket: #104 

### Acceptance Criteria
- [ ] Cart dummy data matches expected structure
- [x] On page load cart is filled with this data
- [x] Dummy data added in a way that can be easily removed once front-end prototyping completed

### Discoveries
<!-- Anything to note/for others' understanding -->
- Cart type does not match the actual backend data. A ticket has been created to check types once all three parsers are complete

### Testing
<!-- Notes on how to manual test, evidence of added tests passing with 80% coverage etc -->
Using React DevTools Browser extension, CartProvider can be inspected and data seen to be populating state on load.

### Checklist
- [x] tests passing
- [x] applied relevant labels to PR ***(`chore`/`feat`/`fix` etc)***
- [x] added screenshots/recordings ***(if applicable)***


### Screenshots/Recordings ***(optional)***
<img width="722" height="590" alt="Screenshot 2025-08-06 160045" src="https://github.com/user-attachments/assets/280e41d3-5ca7-4bb3-ae69-86028fc5ca9e" />
