### PR TITLE
chore:  global types

### DIFF
--- a/frontend/src/context/CartContext.tsx
+++ b/frontend/src/context/CartContext.tsx
@@ -1,7 +1,5 @@
 import { createContext, type ReactNode, useContext, useState } from "react";
 
-import type { Cart } from "@/types/Cart.types";
-
 import { initialCart } from "./utils/initialCart";
 
 type CartContextType = {

--- a/frontend/src/context/utils/initialCart.ts
+++ b/frontend/src/context/utils/initialCart.ts
@@ -1,5 +1,3 @@
-import type { Cart } from "@/types/Cart.types";
-
 // TODO: This (temporary) cart does not match current Cart type
 // `as Cart` is used to satisfy type checking, but replace with:
 // export const initialCart: Cart = {

--- a/frontend/src/types/Cart.types.d.ts
+++ b/frontend/src/types/Cart.types.d.ts
@@ -1,12 +1,10 @@
-import { Product } from "./Product.types";
-
-export type Cart = {
+type Cart = {
   nw: CartItem[];
   pns: CartItem[];
   wls: CartItem[];
 };
 
-export type CartItem = {
+type CartItem = {
   id: string;
   product: Product;
   quantity: number;

--- a/frontend/src/types/Price.types.d.ts
+++ b/frontend/src/types/Price.types.d.ts
@@ -1,4 +1,4 @@
-export type Price = {
+type Price = {
   value: string;
   per?: string;
   unitPrice: string;

--- a/frontend/src/types/Product.types.d.ts
+++ b/frontend/src/types/Product.types.d.ts
@@ -1,7 +1,4 @@
-import { Price } from "./Price.types";
-import { Promo } from "./Promo.types";
-
-export type Product = {
+type Product = {
   id: string;
   title: string;
   amt?: string;

--- a/frontend/src/types/Promo.types.d.ts
+++ b/frontend/src/types/Promo.types.d.ts
@@ -1,4 +1,4 @@
-export type Promo = NWPromo | PNSPromo | WLSPromo;
+type Promo = NWPromo | PNSPromo | WLSPromo;
 
 type NWPromo = {
   tag: string;


### PR DESCRIPTION
<!-- Description of task purpose -->
Our front-end types used to be global declarations, but for some reason we currently need to import/export them.

Not having to import them everywhere was cleaner and it would be nice to return to this.

Project ticket: #77 

### Acceptance Criteria
- [x] types no longer need to be imported into files
OR
- [ ] reasoning added to ADR why we are continuing to import/export

### Discoveries
<!-- Anything to note/for others' understanding -->
Having the `export` keyword before a type declaration invalidated the declaration. Doing so meant it _had_ to be imported.

The config we previously set up was still good, so once `export` was removed the types were once more globally recognised.

> TLDR: Do not use export if you want it to be global.

### Testing
<!-- Notes on how to manual test, evidence of added tests passing with 80% coverage etc -->

### Checklist
- [x] tests passing
- [x] applied relevant labels to PR ***(`chore`/`feat`/`fix` etc)***
- [x] added screenshots/recordings ***(if applicable)***


### Screenshots/Recordings ***(optional)***
