### PR TITLE
chore: #110 - parser checks and consistency updates

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.4
+FROM ruby:3.4.1-bullseye
 
 # Install system dependencies
 RUN apt-get update -qq && apt-get install -y \

--- a/backend/app/services/new_world_parser.rb
+++ b/backend/app/services/new_world_parser.rb
@@ -32,12 +32,12 @@ class NewWorldParser
   # @return [Product || nil] The product details or nil if parsing fails
   def self.parse_one_product(node)
     ticketed_prices = extract_price_and_promo(node)
+    product_title = "#{extract_name(node)} #{extract_amt(node)}"
 
     {
       supermarket: "nw",
       id: extract_id(node),
-      title: extract_name(node),
-      amt: extract_amt(node),
+      title: product_title,
       image: extract_image(node),
       productPageUrl: extract_product_page_url(node),
       price: ticketed_prices[:price],
@@ -86,7 +86,8 @@ class NewWorldParser
   # @return [String] The product page URL
   def self.extract_product_page_url(node)
     dirty_link = node.at_css("a", node)&.[]("href")
-    dirty_link.split("#").first
+    link = dirty_link.split("#").first
+    "https://www.newworld.co.nz#{link}"
   end
 
   # extract_price_and_promo - Retrieves the price and promo details

--- a/backend/app/services/paknsave_parser.rb
+++ b/backend/app/services/paknsave_parser.rb
@@ -31,11 +31,12 @@ class PaknsaveParser
   # @param node [Nokogiri::XML::Element] The parent tag containing product details
   # @return [Product || nil] The product details or nil if parsing fails
   def self.parse_one_product(node)
+    product_title = "#{extract_name(node)} #{extract_amt(node)}"
+
     {
       supermarket: "pns",
       id: extract_id(node),
-      title: extract_name(node),
-      amt: extract_amt(node),
+      title: product_title,
       image: extract_img(node),
       productPageUrl: extract_product_page_url(node),
       price: extract_price(node),
@@ -84,7 +85,8 @@ class PaknsaveParser
   # @return [String] The product page URL
   def self.extract_product_page_url(node)
     dirty_link = node.at_css("a")&.[]("href")
-    dirty_link.split("#").first
+    link = dirty_link.split("#").first
+    "https://www.paknsave.co.nz#{link}"
   end
 
   # extract_price - Retrieves the price details

--- a/backend/app/services/woolworths_parser.rb
+++ b/backend/app/services/woolworths_parser.rb
@@ -42,7 +42,6 @@ class WoolworthsParser
       supermarket: "wls",
       id: extract_id(node),
       title: title,
-      amt: extract_amt(title),
       image: extract_image(node),
       productPageUrl: extract_product_page_url(node),
       price: ticketed_prices[:price],
@@ -71,22 +70,6 @@ class WoolworthsParser
       &.text
       &.gsub(/\s+/, " ") # <- Replaces whitespace chunks with a single space
       &.strip
-  end
-
-  # extract_amt - Extracts the amount (e.g., weight or volume) from the product title
-  #
-  # @param title [String, nil] The product title text
-  # @return [String, nil] The extracted amount string (e.g., "500g", "0.6-0.8kg"), or nil if not found
-  #
-  # @example
-  #   extract_amt("Chicken Thighs 580g - 800g") # => "580g-800g"
-  #   extract_amt("Milk 2L")                    # => "2L"
-  #   extract_amt(nil)                          # => nil
-  def self.extract_amt(title)
-    return nil unless title
-    # Match patterns like "0.6-0.8kg", "580g - 800g", "1.0kg - 1.35kg", "1.3-1.9kg", "500g"
-    match = title.match(/(\d+(?:\.\d+)?(?:\s*[–-]\s*\d+(?:\.\d+)?)(?:kg|g|ml|l)|\d+(?:\.\d+)?(?:kg|g|ml|l))/i)
-    match[1].gsub(/\s+/, "") if match
   end
 
   # extract_image - Extracts the product image URL from the node

--- a/backend/spec/fixtures/pns_curated.html
+++ b/backend/spec/fixtures/pns_curated.html
@@ -687,6 +687,396 @@
                 </div>
 
                 <!--  -->
+                <!-- UNITLESS -->
+                <div class="owfhtz0" data-testid="product-5297621-EA-000">
+                  <div class="owfhtzj"></div><a class="owfhtz2"
+                    href="/shop/product/5297621_ea_000pns?name=speight%27s-summit-ultra-low-carb-larger-beer-cans#JTdCJTIyYWxnb2xpYUFuYWx5dGljcyUyMiUzQSU3QiUyMnNlYXJjaFF1ZXJ5SUQlMjIlM0ElMjIyNWEyZTVhOThiZmUyZjIzNjA2ZTliMmZhZGNmYzk1ZiUyMiUyQyUyMnNlYXJjaFBvc2l0aW9uJTIyJTNBMSU3RCU3RA==">
+                    <p data-testid="product-title">Speight's Summit Ultra Low Carb Larger Beer Cans</p>
+                    <p data-testid="product-subtitle">24 x 330ml</p>
+                  </a>
+                  <div class="owfhtzl">
+                    <div class="owfhtz7"><a tabindex="-1"
+                        href="/shop/product/5297621_ea_000pns?name=speight%27s-summit-ultra-low-carb-larger-beer-cans#JTdCJTIyYWxnb2xpYUFuYWx5dGljcyUyMiUzQSU3QiUyMnNlYXJjaFF1ZXJ5SUQlMjIlM0ElMjIyNWEyZTVhOThiZmUyZjIzNjA2ZTliMmZhZGNmYzk1ZiUyMiUyQyUyMnNlYXJjaFBvc2l0aW9uJTIyJTNBMSU3RCU3RA==">
+                        <div class="_1buatj80 owfhtz8"><img alt="Speight's Summit Ultra Low Carb Larger Beer Cans"
+                            data-testid="product-image" loading="lazy" width="140" height="140" decoding="async"
+                            data-nimg="1" class="_1buatj82"
+                            srcset="https://a.fsimg.co.nz/product/retail/fan/image/400x400/5297621.png?w=256 1x, https://a.fsimg.co.nz/product/retail/fan/image/400x400/5297621.png?w=384 2x"
+                            src="https://a.fsimg.co.nz/product/retail/fan/image/400x400/5297621.png?w=384"
+                            style="color: transparent;"></div>
+                      </a></div>
+                    <div class="owfhtza" data-testid="product-card-details">
+                      <div class="owfhtzk">
+                        <div>
+                          <div data-bv-show="inline_rating" data-bv-product-id="5297621" data-bv-ready="true">
+                            <div class="">
+                              <div id="ef250f9b-d6a4-43f8-835e-30039568aaaa"
+                                class="bv_main_container bv_hover bv_inline_rating_container_left bv_hide_visibility">
+                                <div class="bv_stars_component_container" aria-hidden="true">
+                                  <div class="bv_stars_button_container"><span class="bv_stars_svg_no_wrap"
+                                      aria-hidden="true"><svg focusable="false" xmlns="http://www.w3.org/2000/svg"
+                                        width="20px" height="20px" viewBox="0 0 25 25"
+                                        style="width: 20px !important; height: 20px !important;">
+                                        <polygon points=""
+                                          style="fill: url(&quot;#bv_inline_ratings_star_filled_0_0.00_Tt2Kb1FlMU&quot;) !important;">
+                                        </polygon>
+                                        <path
+                                          d="M24.8676481,9.0008973 C24.7082329,8.54565507 24.2825324,8.23189792 23.7931772,8.20897226 L16.1009423,8.20897226 L13.658963,0.793674161 C13.4850788,0.296529881 12.9965414,-0.0267985214 12.4623931,0.00174912135 L12.4623931,0.00174912135 C11.9394964,-0.00194214302 11.4747239,0.328465149 11.3146628,0.81767189 L8.87268352,8.23296999 L1.20486846,8.23296999 C0.689809989,8.22949161 0.230279943,8.55030885 0.0640800798,9.0294023 C-0.102119784,9.50849575 0.0623083246,10.0383495 0.472274662,10.3447701 L6.69932193,14.9763317 L4.25734261,22.4396253 C4.08483744,22.9295881 4.25922828,23.4727606 4.68662933,23.7767181 C5.11403038,24.0806756 5.69357086,24.0736812 6.11324689,23.7595003 L12.6333317,18.9599546 L19.1778362,23.7595003 C19.381674,23.9119158 19.6299003,23.9960316 19.8860103,23.9994776 C20.2758842,24.0048539 20.6439728,23.8232161 20.8724402,23.5127115 C21.1009077,23.202207 21.1610972,22.8017824 21.0337405,22.4396253 L18.5917612,14.9763317 L24.6967095,10.3207724 C25.0258477,9.95783882 25.0937839,9.43328063 24.8676481,9.0008973 Z"
+                                          style="fill: url(&quot;#bv_inline_ratings_star_filled_0_0.00_Tt2Kb1FlMU&quot;) !important;">
+                                        </path>
+                                        <defs>
+                                          <linearGradient id="bv_inline_ratings_star_filled_0_0.00_Tt2Kb1FlMU"
+                                            x1="0.00%" y1="0%" x2="100%" y2="0%">
+                                            <stop offset="0%" style="stop-color: rgb(208, 132, 16); stop-opacity: 1;">
+                                            </stop>
+                                            <stop offset="1%" style="stop-color: rgb(204, 204, 204); stop-opacity: 1;">
+                                            </stop>
+                                          </linearGradient>
+                                        </defs>
+                                      </svg><svg focusable="false" xmlns="http://www.w3.org/2000/svg" width="20px"
+                                        height="20px" viewBox="0 0 25 25"
+                                        style="width: 20px !important; height: 20px !important;">
+                                        <polygon points=""
+                                          style="fill: url(&quot;#bv_inline_ratings_star_filled_1_0.00_1zFhMYrr10&quot;) !important;">
+                                        </polygon>
+                                        <path
+                                          d="M24.8676481,9.0008973 C24.7082329,8.54565507 24.2825324,8.23189792 23.7931772,8.20897226 L16.1009423,8.20897226 L13.658963,0.793674161 C13.4850788,0.296529881 12.9965414,-0.0267985214 12.4623931,0.00174912135 L12.4623931,0.00174912135 C11.9394964,-0.00194214302 11.4747239,0.328465149 11.3146628,0.81767189 L8.87268352,8.23296999 L1.20486846,8.23296999 C0.689809989,8.22949161 0.230279943,8.55030885 0.0640800798,9.0294023 C-0.102119784,9.50849575 0.0623083246,10.0383495 0.472274662,10.3447701 L6.69932193,14.9763317 L4.25734261,22.4396253 C4.08483744,22.9295881 4.25922828,23.4727606 4.68662933,23.7767181 C5.11403038,24.0806756 5.69357086,24.0736812 6.11324689,23.7595003 L12.6333317,18.9599546 L19.1778362,23.7595003 C19.381674,23.9119158 19.6299003,23.9960316 19.8860103,23.9994776 C20.2758842,24.0048539 20.6439728,23.8232161 20.8724402,23.5127115 C21.1009077,23.202207 21.1610972,22.8017824 21.0337405,22.4396253 L18.5917612,14.9763317 L24.6967095,10.3207724 C25.0258477,9.95783882 25.0937839,9.43328063 24.8676481,9.0008973 Z"
+                                          style="fill: url(&quot;#bv_inline_ratings_star_filled_1_0.00_1zFhMYrr10&quot;) !important;">
+                                        </path>
+                                        <defs>
+                                          <linearGradient id="bv_inline_ratings_star_filled_1_0.00_1zFhMYrr10"
+                                            x1="0.00%" y1="0%" x2="100%" y2="0%">
+                                            <stop offset="0%" style="stop-color: rgb(208, 132, 16); stop-opacity: 1;">
+                                            </stop>
+                                            <stop offset="1%" style="stop-color: rgb(204, 204, 204); stop-opacity: 1;">
+                                            </stop>
+                                          </linearGradient>
+                                        </defs>
+                                      </svg><svg focusable="false" xmlns="http://www.w3.org/2000/svg" width="20px"
+                                        height="20px" viewBox="0 0 25 25"
+                                        style="width: 20px !important; height: 20px !important;">
+                                        <polygon points=""
+                                          style="fill: url(&quot;#bv_inline_ratings_star_filled_2_0.00_EFXQfawV6m&quot;) !important;">
+                                        </polygon>
+                                        <path
+                                          d="M24.8676481,9.0008973 C24.7082329,8.54565507 24.2825324,8.23189792 23.7931772,8.20897226 L16.1009423,8.20897226 L13.658963,0.793674161 C13.4850788,0.296529881 12.9965414,-0.0267985214 12.4623931,0.00174912135 L12.4623931,0.00174912135 C11.9394964,-0.00194214302 11.4747239,0.328465149 11.3146628,0.81767189 L8.87268352,8.23296999 L1.20486846,8.23296999 C0.689809989,8.22949161 0.230279943,8.55030885 0.0640800798,9.0294023 C-0.102119784,9.50849575 0.0623083246,10.0383495 0.472274662,10.3447701 L6.69932193,14.9763317 L4.25734261,22.4396253 C4.08483744,22.9295881 4.25922828,23.4727606 4.68662933,23.7767181 C5.11403038,24.0806756 5.69357086,24.0736812 6.11324689,23.7595003 L12.6333317,18.9599546 L19.1778362,23.7595003 C19.381674,23.9119158 19.6299003,23.9960316 19.8860103,23.9994776 C20.2758842,24.0048539 20.6439728,23.8232161 20.8724402,23.5127115 C21.1009077,23.202207 21.1610972,22.8017824 21.0337405,22.4396253 L18.5917612,14.9763317 L24.6967095,10.3207724 C25.0258477,9.95783882 25.0937839,9.43328063 24.8676481,9.0008973 Z"
+                                          style="fill: url(&quot;#bv_inline_ratings_star_filled_2_0.00_EFXQfawV6m&quot;) !important;">
+                                        </path>
+                                        <defs>
+                                          <linearGradient id="bv_inline_ratings_star_filled_2_0.00_EFXQfawV6m"
+                                            x1="0.00%" y1="0%" x2="100%" y2="0%">
+                                            <stop offset="0%" style="stop-color: rgb(208, 132, 16); stop-opacity: 1;">
+                                            </stop>
+                                            <stop offset="1%" style="stop-color: rgb(204, 204, 204); stop-opacity: 1;">
+                                            </stop>
+                                          </linearGradient>
+                                        </defs>
+                                      </svg><svg focusable="false" xmlns="http://www.w3.org/2000/svg" width="20px"
+                                        height="20px" viewBox="0 0 25 25"
+                                        style="width: 20px !important; height: 20px !important;">
+                                        <polygon points=""
+                                          style="fill: url(&quot;#bv_inline_ratings_star_filled_3_0.00_fxk4E0LZuu&quot;) !important;">
+                                        </polygon>
+                                        <path
+                                          d="M24.8676481,9.0008973 C24.7082329,8.54565507 24.2825324,8.23189792 23.7931772,8.20897226 L16.1009423,8.20897226 L13.658963,0.793674161 C13.4850788,0.296529881 12.9965414,-0.0267985214 12.4623931,0.00174912135 L12.4623931,0.00174912135 C11.9394964,-0.00194214302 11.4747239,0.328465149 11.3146628,0.81767189 L8.87268352,8.23296999 L1.20486846,8.23296999 C0.689809989,8.22949161 0.230279943,8.55030885 0.0640800798,9.0294023 C-0.102119784,9.50849575 0.0623083246,10.0383495 0.472274662,10.3447701 L6.69932193,14.9763317 L4.25734261,22.4396253 C4.08483744,22.9295881 4.25922828,23.4727606 4.68662933,23.7767181 C5.11403038,24.0806756 5.69357086,24.0736812 6.11324689,23.7595003 L12.6333317,18.9599546 L19.1778362,23.7595003 C19.381674,23.9119158 19.6299003,23.9960316 19.8860103,23.9994776 C20.2758842,24.0048539 20.6439728,23.8232161 20.8724402,23.5127115 C21.1009077,23.202207 21.1610972,22.8017824 21.0337405,22.4396253 L18.5917612,14.9763317 L24.6967095,10.3207724 C25.0258477,9.95783882 25.0937839,9.43328063 24.8676481,9.0008973 Z"
+                                          style="fill: url(&quot;#bv_inline_ratings_star_filled_3_0.00_fxk4E0LZuu&quot;) !important;">
+                                        </path>
+                                        <defs>
+                                          <linearGradient id="bv_inline_ratings_star_filled_3_0.00_fxk4E0LZuu"
+                                            x1="0.00%" y1="0%" x2="100%" y2="0%">
+                                            <stop offset="0%" style="stop-color: rgb(208, 132, 16); stop-opacity: 1;">
+                                            </stop>
+                                            <stop offset="1%" style="stop-color: rgb(204, 204, 204); stop-opacity: 1;">
+                                            </stop>
+                                          </linearGradient>
+                                        </defs>
+                                      </svg><svg focusable="false" xmlns="http://www.w3.org/2000/svg" width="20px"
+                                        height="20px" viewBox="0 0 25 25"
+                                        style="width: 20px !important; height: 20px !important;">
+                                        <polygon points=""
+                                          style="fill: url(&quot;#bv_inline_ratings_star_filled_4_0.00_ASO3SgXK5s&quot;) !important;">
+                                        </polygon>
+                                        <path
+                                          d="M24.8676481,9.0008973 C24.7082329,8.54565507 24.2825324,8.23189792 23.7931772,8.20897226 L16.1009423,8.20897226 L13.658963,0.793674161 C13.4850788,0.296529881 12.9965414,-0.0267985214 12.4623931,0.00174912135 L12.4623931,0.00174912135 C11.9394964,-0.00194214302 11.4747239,0.328465149 11.3146628,0.81767189 L8.87268352,8.23296999 L1.20486846,8.23296999 C0.689809989,8.22949161 0.230279943,8.55030885 0.0640800798,9.0294023 C-0.102119784,9.50849575 0.0623083246,10.0383495 0.472274662,10.3447701 L6.69932193,14.9763317 L4.25734261,22.4396253 C4.08483744,22.9295881 4.25922828,23.4727606 4.68662933,23.7767181 C5.11403038,24.0806756 5.69357086,24.0736812 6.11324689,23.7595003 L12.6333317,18.9599546 L19.1778362,23.7595003 C19.381674,23.9119158 19.6299003,23.9960316 19.8860103,23.9994776 C20.2758842,24.0048539 20.6439728,23.8232161 20.8724402,23.5127115 C21.1009077,23.202207 21.1610972,22.8017824 21.0337405,22.4396253 L18.5917612,14.9763317 L24.6967095,10.3207724 C25.0258477,9.95783882 25.0937839,9.43328063 24.8676481,9.0008973 Z"
+                                          style="fill: url(&quot;#bv_inline_ratings_star_filled_4_0.00_ASO3SgXK5s&quot;) !important;">
+                                        </path>
+                                        <defs>
+                                          <linearGradient id="bv_inline_ratings_star_filled_4_0.00_ASO3SgXK5s"
+                                            x1="0.00%" y1="0%" x2="100%" y2="0%">
+                                            <stop offset="0%" style="stop-color: rgb(208, 132, 16); stop-opacity: 1;">
+                                            </stop>
+                                            <stop offset="1%" style="stop-color: rgb(204, 204, 204); stop-opacity: 1;">
+                                            </stop>
+                                          </linearGradient>
+                                        </defs>
+                                      </svg></span></div>
+                                </div>
+                                <div class="bv_sub_container">
+                                  <div class="bv_averageRating_component_container" aria-hidden="true">
+                                    <div class="bv_text">0.0</div>
+                                  </div>
+                                  <div class="bv_numReviews_component_container" aria-hidden="true">
+                                    <div class="bv_text">(0)</div>
+                                  </div>
+                                </div>
+                                <div class="bv-off-screen">0.0 out of 5 stars. </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="owfhtzb">
+                          <div class="zp4phe9 owfhtzh zzkm2v0" data-testid="price">
+                            <p data-testid="price-dollars" font-weight="900" class="zzkm2v5 _10e5eu83i">43</p>
+                            <div class="zp4phe9 zp4phe19 zzkm2v1">
+                              <p data-testid="price-cents" font-weight="900" class="zzkm2va _10e5eu83i">49</p>
+                              <p font-weight="900" data-testid="price-per" class="zzkm2vf _10e5eu83i _10e5eu8bi">ea</p>
+                            </div>
+                          </div>
+                          <div class="owfhtze owfhtzc">
+                            <p data-testid="non-promo-unit-price" class="_10e5eu89 _10e5eu820 _10e5eu850"></p>
+                          </div>
+                          <div><button type="button" class="_19anq540" data-testid="add-to-list"><svg
+                                viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="_19anq541">
+                                <path fill-rule="evenodd" clip-rule="evenodd"
+                                  d="M6.88567 6.31579C7.34201 6.31579 7.71195 6.68844 7.71195 7.14812C7.71195 7.6078 7.34201 7.98045 6.88567 7.98045H1.65256V22.3353H15.7159V16.301C15.7159 15.8413 16.0858 15.4686 16.5421 15.4686C16.9985 15.4686 17.3684 15.8413 17.3684 16.301V23.1677C17.3684 23.6274 16.9985 24 16.5421 24H0.826281C0.369939 24 0 23.6274 0 23.1677V7.14812C0 6.68844 0.369939 6.31579 0.826281 6.31579H6.88567ZM13.6925 18C14.153 18 14.5263 18.3535 14.5263 18.7895C14.5263 19.2255 14.153 19.5789 13.6925 19.5789H4.62329C4.16279 19.5789 3.78947 19.2255 3.78947 18.7895C3.78947 18.3535 4.16279 18 4.62329 18H13.6925ZM9.92365 14.5263C10.3728 14.5263 10.7368 14.8798 10.7368 15.3158C10.7368 15.7518 10.3728 16.1053 9.92365 16.1053H4.60267C4.15355 16.1053 3.78947 15.7518 3.78947 15.3158C3.78947 14.8798 4.15355 14.5263 4.60267 14.5263H9.92365ZM23.9911 7.37264C24.1365 10.1899 22.4588 12.1978 21.9583 12.7467C21.7402 12.9847 19.7213 15.0795 16.6007 15.1551L16.4162 15.1579C12.3498 15.1533 9.0188 11.9395 8.84825 7.88502L8.84405 7.7619C8.75027 3.57602 12.0579 0.104269 16.2372 0.00184588C20.644 -0.09617 23.8121 3.72645 23.9911 7.37264ZM16.3966 1.68212H16.2792C13.0265 1.76162 10.4514 4.46211 10.5218 7.71989C10.6051 10.9213 13.2185 13.4742 16.4162 13.4776H16.5588C19.0222 13.4188 20.6636 11.6797 20.7307 11.6041C21.0103 11.2989 22.4252 9.67181 22.3162 7.46225C22.1444 4.28683 19.5705 1.77361 16.3966 1.68212ZM6.1015 10.7368C6.56866 10.7368 6.94737 11.0903 6.94737 11.5263C6.94737 11.9623 6.56866 12.3158 6.1015 12.3158H4.31955C3.85239 12.3158 3.47368 11.9623 3.47368 11.5263C3.47368 11.0903 3.85239 10.7368 4.31955 10.7368H6.1015ZM16.5789 3.47368C17.015 3.47368 17.3684 3.84575 17.3684 4.30471V6.63158H19.3978C19.8466 6.63158 20.2105 6.98504 20.2105 7.42105C20.2105 7.85707 19.8466 8.21053 19.3978 8.21053H17.3684V10.2216C17.3684 10.6806 17.015 11.0526 16.5789 11.0526C16.1429 11.0526 15.7895 10.6806 15.7895 10.2216V8.21053H13.7601C13.3112 8.21053 12.9474 7.85707 12.9474 7.42105C12.9474 6.98504 13.3112 6.63158 13.7601 6.63158H15.7895V4.30471C15.7895 3.84575 16.1429 3.47368 16.5789 3.47368Z"
+                                  fill="currentColor"></path>
+                              </svg><span data-testid="visually-hidden" class="_1dfig0v0">Add to list</span></button>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="owfhtzg">
+                        <div class="_1c8umnv0">
+                          <div class="_1q9jehg0">
+                            <div class="_1q9jehg1">
+                              <div class="zp4pheki zp4phe9 zp4phe19 _17gvktc1">
+                                <div class="zp4phe3r zp4phe9 _1dfig0v0"><label for=":rq:"
+                                    class="_10e5eu8i _10e5eu829 _10e5eu840 _10e5eu84r">Quantity</label></div>
+                                <div class="m8owjo0"><input class="_1q9jehg2 m8owjo1 m8owjo2" id=":rq:"
+                                    aria-invalid="false" aria-required="true" data-testid="quantity-edit" type="number"
+                                    step="1" aria-label="Quantity" value="1">
+                                  <div class="m8owjo5"></div>
+                                </div>
+                              </div><span class="_1q9jehg3" data-testid="quantity-unit">ea</span>
+                            </div><button data-testid="add-to-cart" theme="tertiary" type="button"
+                              class="_1c9qavo0 _1c9qavo3 _1c9qavo7 _1q9jehg7">Add</button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="owfhtzm"></div>
+                </div>
+
+                <!--  -->
+                <!-- UNITLESS PROMO -->
+                <div class="owfhtz0" data-testid="product-5220257-EA-000">
+                  <div class="owfhtzj">
+                    <div class="wgonz71 wgonz72 wgonz74" data-testid="product-decal-6000"><svg width="80" height="42"
+                        viewBox="0 0 64 30" fill="none" xmlns="http://www.w3.org/2000/svg" aria-label="6000 badge">
+                        <path
+                          d="M15 4V14.2966H20.3935V12.4579H17.5741V10.0063H20.2709V8.16767H17.5741V5.7161H20.3935V4H15Z"
+                          fill="white"></path>
+                        <path
+                          d="M22.4774 8.78056L20.6387 4H23.0902L24.1934 7.30962L25.1741 4H27.6256L25.787 8.78056L27.7482 14.2966H25.1741L24.1934 10.3741L23.2128 14.2966H20.7613L22.4774 8.78056Z"
+                          fill="white"></path>
+                        <path d="M27.8711 4H34.4903V5.7161H32.4065V14.2966H29.9549V5.7161H27.8711V4Z" fill="white">
+                        </path>
+                        <path fill-rule="evenodd" clip-rule="evenodd"
+                          d="M35.1035 14.3V4.0034H38.9035C39.6798 3.96254 41.2324 4.27308 41.2324 5.84208V7.31302C41.1916 7.84419 40.8892 8.90654 40.0067 8.90654C40.4153 8.90654 41.355 9.22524 41.355 10.5001V13.6871C41.355 13.698 41.355 13.7094 41.3549 13.7213C41.3536 13.9337 41.3514 14.3 41.7228 14.3H39.3938C39.2712 14.3 39.026 14.0058 39.026 13.3194V10.5001C39.026 10.2958 38.8544 10.0097 38.168 10.0097H37.4325V14.3H35.1035ZM37.4325 8.17107V5.7195H38.2906C38.5357 5.7195 39.026 5.86659 39.026 6.45497V7.4356C39.026 7.68075 38.8789 8.17107 38.2906 8.17107H37.4325Z"
+                          fill="white"></path>
+                        <path fill-rule="evenodd" clip-rule="evenodd"
+                          d="M41.9668 14.2966L44.0506 4H47.4828L49.5667 14.2966H47.1151L46.7474 11.9676H44.7861L44.4184 14.2966H41.9668ZM45.7667 5.7161L45.0313 10.1289H46.5022L45.7667 5.7161Z"
+                          fill="white"></path>
+                        <path
+                          d="M20.6955 15.9733L20.4425 15.997L20.4702 16.2495L21.4591 25.2601L21.4861 25.506L21.7323 25.4816L42.9934 23.3752L43.2452 23.3503L43.2172 23.0988L42.2283 14.2052L42.2012 13.961L41.9566 13.9839L20.6955 15.9733Z"
+                          fill="#FFD600" stroke="black" stroke-width="0.5"></path>
+                        <path
+                          d="M23.0364 24.0845L22.2598 17.3778L24.1459 17.173L24.8116 22.7022L26.7532 22.4974L26.9196 23.7262L23.0364 24.0845Z"
+                          fill="black"></path>
+                        <path
+                          d="M33.908 23.0095L32.1328 16.404L33.908 16.2003L35.1284 21.3712L35.4613 16.0467L37.6802 15.8419L39.3445 20.9616L39.2335 15.6883L41.0087 15.4835L40.7868 22.2927L38.4014 22.4975L36.7926 17.4802L36.3489 22.8047L33.908 23.0095Z"
+                          fill="black"></path>
+                        <path fill-rule="evenodd" clip-rule="evenodd"
+                          d="M31.7006 18.289C31.6468 17.7969 31.4854 16.3208 29.4754 16.5079L28.4704 16.6015C26.4603 16.7887 26.6217 18.2648 26.6755 18.7569L26.9983 21.7092C27.0521 22.2013 27.2134 23.6774 29.2235 23.4903L30.2285 23.3967C32.2385 23.2095 32.0771 21.7334 32.0233 21.2413L31.7006 18.289ZM29.2378 17.6898C29.428 17.6721 29.8191 17.7351 29.8621 18.1288L30.2566 21.7372C30.2996 22.1308 29.93 22.2646 29.7399 22.2823L29.5497 22.3C29.3596 22.3177 28.9685 22.2548 28.9255 21.8611L28.531 18.2527C28.488 17.8591 28.8575 17.7253 29.0477 17.7076L29.2378 17.6898Z"
+                          fill="black"></path>
+                      </svg></div>
+                  </div><a class="owfhtz2"
+                    href="/shop/product/5220257_ea_000pns?name=speight%27s-summit-ultra-low-carb-lager-beer-bottles#JTdCJTIyYWxnb2xpYUFuYWx5dGljcyUyMiUzQSU3QiUyMnNlYXJjaFF1ZXJ5SUQlMjIlM0ElMjIyNWEyZTVhOThiZmUyZjIzNjA2ZTliMmZhZGNmYzk1ZiUyMiUyQyUyMnNlYXJjaFBvc2l0aW9uJTIyJTNBMyU3RCU3RA==">
+                    <p data-testid="product-title">Speight's Summit Ultra Low Carb Lager Beer Bottles</p>
+                    <p data-testid="product-subtitle">12 x 330ml</p>
+                  </a>
+                  <div class="owfhtzl">
+                    <div class="owfhtz7"><a tabindex="-1"
+                        href="/shop/product/5220257_ea_000pns?name=speight%27s-summit-ultra-low-carb-lager-beer-bottles#JTdCJTIyYWxnb2xpYUFuYWx5dGljcyUyMiUzQSU3QiUyMnNlYXJjaFF1ZXJ5SUQlMjIlM0ElMjIyNWEyZTVhOThiZmUyZjIzNjA2ZTliMmZhZGNmYzk1ZiUyMiUyQyUyMnNlYXJjaFBvc2l0aW9uJTIyJTNBMyU3RCU3RA==">
+                        <div class="_1buatj80 owfhtz8"><img alt="Speight's Summit Ultra Low Carb Lager Beer Bottles"
+                            data-testid="product-image" loading="lazy" width="140" height="140" decoding="async"
+                            data-nimg="1" class="_1buatj82"
+                            srcset="https://a.fsimg.co.nz/product/retail/fan/image/400x400/5220257.png?w=256 1x, https://a.fsimg.co.nz/product/retail/fan/image/400x400/5220257.png?w=384 2x"
+                            src="https://a.fsimg.co.nz/product/retail/fan/image/400x400/5220257.png?w=384"
+                            style="color: transparent;"></div>
+                      </a></div>
+                    <div class="owfhtza" data-testid="product-card-details">
+                      <div class="owfhtzk">
+                        <div>
+                          <div data-bv-show="inline_rating" data-bv-product-id="5220257" data-bv-ready="true">
+                            <div class="">
+                              <div id="f68503c7-baac-4647-a243-9270712152ad"
+                                class="bv_main_container bv_hover bv_inline_rating_container_left bv_hide_visibility">
+                                <div class="bv_stars_component_container" aria-hidden="true">
+                                  <div class="bv_stars_button_container"><span class="bv_stars_svg_no_wrap"
+                                      aria-hidden="true"><svg focusable="false" xmlns="http://www.w3.org/2000/svg"
+                                        width="20px" height="20px" viewBox="0 0 25 25"
+                                        style="width: 20px !important; height: 20px !important;">
+                                        <polygon points=""
+                                          style="fill: url(&quot;#bv_inline_ratings_star_filled_0_0.00_sqEuHpW3eV&quot;) !important;">
+                                        </polygon>
+                                        <path
+                                          d="M24.8676481,9.0008973 C24.7082329,8.54565507 24.2825324,8.23189792 23.7931772,8.20897226 L16.1009423,8.20897226 L13.658963,0.793674161 C13.4850788,0.296529881 12.9965414,-0.0267985214 12.4623931,0.00174912135 L12.4623931,0.00174912135 C11.9394964,-0.00194214302 11.4747239,0.328465149 11.3146628,0.81767189 L8.87268352,8.23296999 L1.20486846,8.23296999 C0.689809989,8.22949161 0.230279943,8.55030885 0.0640800798,9.0294023 C-0.102119784,9.50849575 0.0623083246,10.0383495 0.472274662,10.3447701 L6.69932193,14.9763317 L4.25734261,22.4396253 C4.08483744,22.9295881 4.25922828,23.4727606 4.68662933,23.7767181 C5.11403038,24.0806756 5.69357086,24.0736812 6.11324689,23.7595003 L12.6333317,18.9599546 L19.1778362,23.7595003 C19.381674,23.9119158 19.6299003,23.9960316 19.8860103,23.9994776 C20.2758842,24.0048539 20.6439728,23.8232161 20.8724402,23.5127115 C21.1009077,23.202207 21.1610972,22.8017824 21.0337405,22.4396253 L18.5917612,14.9763317 L24.6967095,10.3207724 C25.0258477,9.95783882 25.0937839,9.43328063 24.8676481,9.0008973 Z"
+                                          style="fill: url(&quot;#bv_inline_ratings_star_filled_0_0.00_sqEuHpW3eV&quot;) !important;">
+                                        </path>
+                                        <defs>
+                                          <linearGradient id="bv_inline_ratings_star_filled_0_0.00_sqEuHpW3eV"
+                                            x1="0.00%" y1="0%" x2="100%" y2="0%">
+                                            <stop offset="0%" style="stop-color: rgb(208, 132, 16); stop-opacity: 1;">
+                                            </stop>
+                                            <stop offset="1%" style="stop-color: rgb(204, 204, 204); stop-opacity: 1;">
+                                            </stop>
+                                          </linearGradient>
+                                        </defs>
+                                      </svg><svg focusable="false" xmlns="http://www.w3.org/2000/svg" width="20px"
+                                        height="20px" viewBox="0 0 25 25"
+                                        style="width: 20px !important; height: 20px !important;">
+                                        <polygon points=""
+                                          style="fill: url(&quot;#bv_inline_ratings_star_filled_1_0.00_IG6YhmUalx&quot;) !important;">
+                                        </polygon>
+                                        <path
+                                          d="M24.8676481,9.0008973 C24.7082329,8.54565507 24.2825324,8.23189792 23.7931772,8.20897226 L16.1009423,8.20897226 L13.658963,0.793674161 C13.4850788,0.296529881 12.9965414,-0.0267985214 12.4623931,0.00174912135 L12.4623931,0.00174912135 C11.9394964,-0.00194214302 11.4747239,0.328465149 11.3146628,0.81767189 L8.87268352,8.23296999 L1.20486846,8.23296999 C0.689809989,8.22949161 0.230279943,8.55030885 0.0640800798,9.0294023 C-0.102119784,9.50849575 0.0623083246,10.0383495 0.472274662,10.3447701 L6.69932193,14.9763317 L4.25734261,22.4396253 C4.08483744,22.9295881 4.25922828,23.4727606 4.68662933,23.7767181 C5.11403038,24.0806756 5.69357086,24.0736812 6.11324689,23.7595003 L12.6333317,18.9599546 L19.1778362,23.7595003 C19.381674,23.9119158 19.6299003,23.9960316 19.8860103,23.9994776 C20.2758842,24.0048539 20.6439728,23.8232161 20.8724402,23.5127115 C21.1009077,23.202207 21.1610972,22.8017824 21.0337405,22.4396253 L18.5917612,14.9763317 L24.6967095,10.3207724 C25.0258477,9.95783882 25.0937839,9.43328063 24.8676481,9.0008973 Z"
+                                          style="fill: url(&quot;#bv_inline_ratings_star_filled_1_0.00_IG6YhmUalx&quot;) !important;">
+                                        </path>
+                                        <defs>
+                                          <linearGradient id="bv_inline_ratings_star_filled_1_0.00_IG6YhmUalx"
+                                            x1="0.00%" y1="0%" x2="100%" y2="0%">
+                                            <stop offset="0%" style="stop-color: rgb(208, 132, 16); stop-opacity: 1;">
+                                            </stop>
+                                            <stop offset="1%" style="stop-color: rgb(204, 204, 204); stop-opacity: 1;">
+                                            </stop>
+                                          </linearGradient>
+                                        </defs>
+                                      </svg><svg focusable="false" xmlns="http://www.w3.org/2000/svg" width="20px"
+                                        height="20px" viewBox="0 0 25 25"
+                                        style="width: 20px !important; height: 20px !important;">
+                                        <polygon points=""
+                                          style="fill: url(&quot;#bv_inline_ratings_star_filled_2_0.00_gbHW4cHsuN&quot;) !important;">
+                                        </polygon>
+                                        <path
+                                          d="M24.8676481,9.0008973 C24.7082329,8.54565507 24.2825324,8.23189792 23.7931772,8.20897226 L16.1009423,8.20897226 L13.658963,0.793674161 C13.4850788,0.296529881 12.9965414,-0.0267985214 12.4623931,0.00174912135 L12.4623931,0.00174912135 C11.9394964,-0.00194214302 11.4747239,0.328465149 11.3146628,0.81767189 L8.87268352,8.23296999 L1.20486846,8.23296999 C0.689809989,8.22949161 0.230279943,8.55030885 0.0640800798,9.0294023 C-0.102119784,9.50849575 0.0623083246,10.0383495 0.472274662,10.3447701 L6.69932193,14.9763317 L4.25734261,22.4396253 C4.08483744,22.9295881 4.25922828,23.4727606 4.68662933,23.7767181 C5.11403038,24.0806756 5.69357086,24.0736812 6.11324689,23.7595003 L12.6333317,18.9599546 L19.1778362,23.7595003 C19.381674,23.9119158 19.6299003,23.9960316 19.8860103,23.9994776 C20.2758842,24.0048539 20.6439728,23.8232161 20.8724402,23.5127115 C21.1009077,23.202207 21.1610972,22.8017824 21.0337405,22.4396253 L18.5917612,14.9763317 L24.6967095,10.3207724 C25.0258477,9.95783882 25.0937839,9.43328063 24.8676481,9.0008973 Z"
+                                          style="fill: url(&quot;#bv_inline_ratings_star_filled_2_0.00_gbHW4cHsuN&quot;) !important;">
+                                        </path>
+                                        <defs>
+                                          <linearGradient id="bv_inline_ratings_star_filled_2_0.00_gbHW4cHsuN"
+                                            x1="0.00%" y1="0%" x2="100%" y2="0%">
+                                            <stop offset="0%" style="stop-color: rgb(208, 132, 16); stop-opacity: 1;">
+                                            </stop>
+                                            <stop offset="1%" style="stop-color: rgb(204, 204, 204); stop-opacity: 1;">
+                                            </stop>
+                                          </linearGradient>
+                                        </defs>
+                                      </svg><svg focusable="false" xmlns="http://www.w3.org/2000/svg" width="20px"
+                                        height="20px" viewBox="0 0 25 25"
+                                        style="width: 20px !important; height: 20px !important;">
+                                        <polygon points=""
+                                          style="fill: url(&quot;#bv_inline_ratings_star_filled_3_0.00_CX3ln3xvqp&quot;) !important;">
+                                        </polygon>
+                                        <path
+                                          d="M24.8676481,9.0008973 C24.7082329,8.54565507 24.2825324,8.23189792 23.7931772,8.20897226 L16.1009423,8.20897226 L13.658963,0.793674161 C13.4850788,0.296529881 12.9965414,-0.0267985214 12.4623931,0.00174912135 L12.4623931,0.00174912135 C11.9394964,-0.00194214302 11.4747239,0.328465149 11.3146628,0.81767189 L8.87268352,8.23296999 L1.20486846,8.23296999 C0.689809989,8.22949161 0.230279943,8.55030885 0.0640800798,9.0294023 C-0.102119784,9.50849575 0.0623083246,10.0383495 0.472274662,10.3447701 L6.69932193,14.9763317 L4.25734261,22.4396253 C4.08483744,22.9295881 4.25922828,23.4727606 4.68662933,23.7767181 C5.11403038,24.0806756 5.69357086,24.0736812 6.11324689,23.7595003 L12.6333317,18.9599546 L19.1778362,23.7595003 C19.381674,23.9119158 19.6299003,23.9960316 19.8860103,23.9994776 C20.2758842,24.0048539 20.6439728,23.8232161 20.8724402,23.5127115 C21.1009077,23.202207 21.1610972,22.8017824 21.0337405,22.4396253 L18.5917612,14.9763317 L24.6967095,10.3207724 C25.0258477,9.95783882 25.0937839,9.43328063 24.8676481,9.0008973 Z"
+                                          style="fill: url(&quot;#bv_inline_ratings_star_filled_3_0.00_CX3ln3xvqp&quot;) !important;">
+                                        </path>
+                                        <defs>
+                                          <linearGradient id="bv_inline_ratings_star_filled_3_0.00_CX3ln3xvqp"
+                                            x1="0.00%" y1="0%" x2="100%" y2="0%">
+                                            <stop offset="0%" style="stop-color: rgb(208, 132, 16); stop-opacity: 1;">
+                                            </stop>
+                                            <stop offset="1%" style="stop-color: rgb(204, 204, 204); stop-opacity: 1;">
+                                            </stop>
+                                          </linearGradient>
+                                        </defs>
+                                      </svg><svg focusable="false" xmlns="http://www.w3.org/2000/svg" width="20px"
+                                        height="20px" viewBox="0 0 25 25"
+                                        style="width: 20px !important; height: 20px !important;">
+                                        <polygon points=""
+                                          style="fill: url(&quot;#bv_inline_ratings_star_filled_4_0.00_LxoFUvsSfy&quot;) !important;">
+                                        </polygon>
+                                        <path
+                                          d="M24.8676481,9.0008973 C24.7082329,8.54565507 24.2825324,8.23189792 23.7931772,8.20897226 L16.1009423,8.20897226 L13.658963,0.793674161 C13.4850788,0.296529881 12.9965414,-0.0267985214 12.4623931,0.00174912135 L12.4623931,0.00174912135 C11.9394964,-0.00194214302 11.4747239,0.328465149 11.3146628,0.81767189 L8.87268352,8.23296999 L1.20486846,8.23296999 C0.689809989,8.22949161 0.230279943,8.55030885 0.0640800798,9.0294023 C-0.102119784,9.50849575 0.0623083246,10.0383495 0.472274662,10.3447701 L6.69932193,14.9763317 L4.25734261,22.4396253 C4.08483744,22.9295881 4.25922828,23.4727606 4.68662933,23.7767181 C5.11403038,24.0806756 5.69357086,24.0736812 6.11324689,23.7595003 L12.6333317,18.9599546 L19.1778362,23.7595003 C19.381674,23.9119158 19.6299003,23.9960316 19.8860103,23.9994776 C20.2758842,24.0048539 20.6439728,23.8232161 20.8724402,23.5127115 C21.1009077,23.202207 21.1610972,22.8017824 21.0337405,22.4396253 L18.5917612,14.9763317 L24.6967095,10.3207724 C25.0258477,9.95783882 25.0937839,9.43328063 24.8676481,9.0008973 Z"
+                                          style="fill: url(&quot;#bv_inline_ratings_star_filled_4_0.00_LxoFUvsSfy&quot;) !important;">
+                                        </path>
+                                        <defs>
+                                          <linearGradient id="bv_inline_ratings_star_filled_4_0.00_LxoFUvsSfy"
+                                            x1="0.00%" y1="0%" x2="100%" y2="0%">
+                                            <stop offset="0%" style="stop-color: rgb(208, 132, 16); stop-opacity: 1;">
+                                            </stop>
+                                            <stop offset="1%" style="stop-color: rgb(204, 204, 204); stop-opacity: 1;">
+                                            </stop>
+                                          </linearGradient>
+                                        </defs>
+                                      </svg></span></div>
+                                </div>
+                                <div class="bv_sub_container">
+                                  <div class="bv_averageRating_component_container" aria-hidden="true">
+                                    <div class="bv_text">0.0</div>
+                                  </div>
+                                  <div class="bv_numReviews_component_container" aria-hidden="true">
+                                    <div class="bv_text">(0)</div>
+                                  </div>
+                                </div>
+                                <div class="bv-off-screen">0.0 out of 5 stars. </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="owfhtzb">
+                          <div class="zp4phe9 owfhtzh zzkm2v0" data-testid="price">
+                            <p data-testid="price-dollars" font-weight="900" class="zzkm2v5 _10e5eu83i">22</p>
+                            <div class="zp4phe9 zp4phe19 zzkm2v1">
+                              <p data-testid="price-cents" font-weight="900" class="zzkm2va _10e5eu83i">99</p>
+                              <p font-weight="900" data-testid="price-per" class="zzkm2vf _10e5eu83i _10e5eu8bi">ea</p>
+                            </div>
+                          </div>
+                          <div class="owfhtze owfhtzc">
+                            <p data-testid="non-promo-unit-price" class="_10e5eu89 _10e5eu820 _10e5eu850"></p>
+                          </div>
+                          <div><button type="button" class="_19anq540" data-testid="add-to-list"><svg
+                                viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="_19anq541">
+                                <path fill-rule="evenodd" clip-rule="evenodd"
+                                  d="M6.88567 6.31579C7.34201 6.31579 7.71195 6.68844 7.71195 7.14812C7.71195 7.6078 7.34201 7.98045 6.88567 7.98045H1.65256V22.3353H15.7159V16.301C15.7159 15.8413 16.0858 15.4686 16.5421 15.4686C16.9985 15.4686 17.3684 15.8413 17.3684 16.301V23.1677C17.3684 23.6274 16.9985 24 16.5421 24H0.826281C0.369939 24 0 23.6274 0 23.1677V7.14812C0 6.68844 0.369939 6.31579 0.826281 6.31579H6.88567ZM13.6925 18C14.153 18 14.5263 18.3535 14.5263 18.7895C14.5263 19.2255 14.153 19.5789 13.6925 19.5789H4.62329C4.16279 19.5789 3.78947 19.2255 3.78947 18.7895C3.78947 18.3535 4.16279 18 4.62329 18H13.6925ZM9.92365 14.5263C10.3728 14.5263 10.7368 14.8798 10.7368 15.3158C10.7368 15.7518 10.3728 16.1053 9.92365 16.1053H4.60267C4.15355 16.1053 3.78947 15.7518 3.78947 15.3158C3.78947 14.8798 4.15355 14.5263 4.60267 14.5263H9.92365ZM23.9911 7.37264C24.1365 10.1899 22.4588 12.1978 21.9583 12.7467C21.7402 12.9847 19.7213 15.0795 16.6007 15.1551L16.4162 15.1579C12.3498 15.1533 9.0188 11.9395 8.84825 7.88502L8.84405 7.7619C8.75027 3.57602 12.0579 0.104269 16.2372 0.00184588C20.644 -0.09617 23.8121 3.72645 23.9911 7.37264ZM16.3966 1.68212H16.2792C13.0265 1.76162 10.4514 4.46211 10.5218 7.71989C10.6051 10.9213 13.2185 13.4742 16.4162 13.4776H16.5588C19.0222 13.4188 20.6636 11.6797 20.7307 11.6041C21.0103 11.2989 22.4252 9.67181 22.3162 7.46225C22.1444 4.28683 19.5705 1.77361 16.3966 1.68212ZM6.1015 10.7368C6.56866 10.7368 6.94737 11.0903 6.94737 11.5263C6.94737 11.9623 6.56866 12.3158 6.1015 12.3158H4.31955C3.85239 12.3158 3.47368 11.9623 3.47368 11.5263C3.47368 11.0903 3.85239 10.7368 4.31955 10.7368H6.1015ZM16.5789 3.47368C17.015 3.47368 17.3684 3.84575 17.3684 4.30471V6.63158H19.3978C19.8466 6.63158 20.2105 6.98504 20.2105 7.42105C20.2105 7.85707 19.8466 8.21053 19.3978 8.21053H17.3684V10.2216C17.3684 10.6806 17.015 11.0526 16.5789 11.0526C16.1429 11.0526 15.7895 10.6806 15.7895 10.2216V8.21053H13.7601C13.3112 8.21053 12.9474 7.85707 12.9474 7.42105C12.9474 6.98504 13.3112 6.63158 13.7601 6.63158H15.7895V4.30471C15.7895 3.84575 16.1429 3.47368 16.5789 3.47368Z"
+                                  fill="currentColor"></path>
+                              </svg><span data-testid="visually-hidden" class="_1dfig0v0">Add to list</span></button>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="owfhtzg">
+                        <div class="_1c8umnv0">
+                          <div class="_1q9jehg0">
+                            <div class="_1q9jehg1">
+                              <div class="zp4pheki zp4phe9 zp4phe19 _17gvktc1">
+                                <div class="zp4phe3r zp4phe9 _1dfig0v0"><label for=":r10:"
+                                    class="_10e5eu8i _10e5eu829 _10e5eu840 _10e5eu84r">Quantity</label></div>
+                                <div class="m8owjo0"><input class="_1q9jehg2 m8owjo1 m8owjo2" id=":r10:"
+                                    aria-invalid="false" aria-required="true" data-testid="quantity-edit" type="number"
+                                    step="1" aria-label="Quantity" value="1">
+                                  <div class="m8owjo5"></div>
+                                </div>
+                              </div><span class="_1q9jehg3" data-testid="quantity-unit">ea</span>
+                            </div><button data-testid="add-to-cart" theme="tertiary" type="button"
+                              class="_1c9qavo0 _1c9qavo3 _1c9qavo7 _1q9jehg7">Add</button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="owfhtzm"></div>
+                </div>
+
+                <!--  -->
                 <!-- NORMAL -->
                 <div class="owfhtz0" data-testid="product-5236771-EA-000">
                   <div class="owfhtzj"></div><a class="owfhtz2"

--- a/backend/spec/fixtures/pns_curated.rb
+++ b/backend/spec/fixtures/pns_curated.rb
@@ -2,10 +2,9 @@ module MockTestData
   PNS_MULTIBUY_OBJ = {
     supermarket: "pns",
     id: "5109655",
-    title: "Mogu Mogu Lychee Juice With Nate De Coco",
-    amt: "320ml",
+    title: "Mogu Mogu Lychee Juice With Nate De Coco 320ml",
     image: "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5109655.png?w=384",
-    productPageUrl: "/shop/product/5109655_ea_000pns?name=mogu-mogu-lychee-juice-with-nate-de-coco",
+    productPageUrl: "https://www.paknsave.co.nz/shop/product/5109655_ea_000pns?name=mogu-mogu-lychee-juice-with-nate-de-coco",
     price: {
       value: "1.89",
       per: "ea",
@@ -24,10 +23,9 @@ module MockTestData
   PNS_LIMIT_OBJ = {
     supermarket: "pns",
     id: "5236273",
-    title: "Karicare 1 Baby Infant Formula From Birth to 6 Months",
-    amt: "900g",
+    title: "Karicare 1 Baby Infant Formula From Birth to 6 Months 900g",
     image: "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5236273.png?w=384",
-    productPageUrl: "/shop/product/5236273_ea_000pns?name=karicare-1-baby-infant-formula-from-birth-to-6-months",
+    productPageUrl: "https://www.paknsave.co.nz/shop/product/5236273_ea_000pns?name=karicare-1-baby-infant-formula-from-birth-to-6-months",
     price: {
       value: "20.39",
       per: "ea",
@@ -45,10 +43,9 @@ module MockTestData
   PNS_EXTRA_LOW_OBJ = {
     supermarket: "pns",
     id: "5011024",
-    title: "Arnott's Shapes Originals Chicken Crimpy Crackers",
-    amt: "175g",
+    title: "Arnott's Shapes Originals Chicken Crimpy Crackers 175g",
     image: "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5011024.png?w=384",
-    productPageUrl: "/shop/product/5011024_ea_000pns?name=arnott%27s-shapes-originals-chicken-crimpy-crackers",
+    productPageUrl: "https://www.paknsave.co.nz/shop/product/5011024_ea_000pns?name=arnott%27s-shapes-originals-chicken-crimpy-crackers",
     price: {
       value: "1.99",
       per: "ea",
@@ -60,13 +57,44 @@ module MockTestData
     },
   }
 
+  PNS_UNITLESS_OBJ = {
+    supermarket: "pns",
+    id: "5297621",
+    title: "Speight's Summit Ultra Low Carb Larger Beer Cans 24 x 330ml",
+    image: "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5297621.png?w=384",
+    productPageUrl: "https://www.paknsave.co.nz/shop/product/5297621_ea_000pns?name=speight%27s-summit-ultra-low-carb-larger-beer-cans",
+    price: {
+      value: "43.49",
+      per: "ea",
+      unitPrice: nil,
+      unit: nil,
+    },
+    promo: nil,
+  }
+
+  PNS_UNITLESS_OBJ_PROMO = {
+    supermarket: "pns",
+    id: "5220257",
+    title: "Speight's Summit Ultra Low Carb Lager Beer Bottles 12 x 330ml",
+    image: "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5220257.png?w=384",
+    productPageUrl: "https://www.paknsave.co.nz/shop/product/5220257_ea_000pns?name=speight%27s-summit-ultra-low-carb-lager-beer-bottles",
+    price: {
+      value: "22.99",
+      per: "ea",
+      unitPrice: nil,
+      unit: nil,
+    },
+    promo: {
+      tag: "Extra Low",
+    },
+  }
+
   PNS_NORMAL_OBJ = {
     supermarket: "pns",
     id: "5236771",
-    title: "Flying Goose Original Sriracha Hot Chilli Sauce",
-    amt: "455ml",
+    title: "Flying Goose Original Sriracha Hot Chilli Sauce 455ml",
     image: "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5236771.png?w=384",
-    productPageUrl: "/shop/product/5236771_ea_000pns?name=flying-goose-original-sriracha-hot-chilli-sauce",
+    productPageUrl: "https://www.paknsave.co.nz/shop/product/5236771_ea_000pns?name=flying-goose-original-sriracha-hot-chilli-sauce",
     price: {
       value: "8.49",
       per: "ea",
@@ -80,6 +108,6 @@ module MockTestData
     query: "mogumogu",
     supermarket: "pns",
     source: "https://www.paknsave.co.nz/shop/search?pg=1&q=mogumogu",
-    results: [PNS_MULTIBUY_OBJ, PNS_LIMIT_OBJ, PNS_EXTRA_LOW_OBJ, PNS_NORMAL_OBJ],
+    results: [PNS_MULTIBUY_OBJ, PNS_LIMIT_OBJ, PNS_EXTRA_LOW_OBJ, PNS_UNITLESS_OBJ, PNS_UNITLESS_OBJ_PROMO, PNS_NORMAL_OBJ],
   }
 end

--- a/backend/spec/fixtures/wls_curated.html
+++ b/backend/spec/fixtures/wls_curated.html
@@ -2204,9 +2204,9 @@
 							class="addToTrolley-btn--add ng-tns-c1519492223-500 ng-trigger ng-trigger-animation ng-star-inserted"
 							_nghost-app-c2304148310=""
 							aria-label="Add tegel free range quick cook chicken steaks chargrilled to trolley" aria-disabled="false"
-							fillstyle="primary" size="default" inline="false" data-orientation="horizontal"
-							fullwidth="true" data-slotendsize="default" data-slotstartsize="default" aria-busy="false"
-							data-completed="false" data-slotend="false" style="pointer-events: auto;"><i _ngcontent-app-c2304148310=""
+							fillstyle="primary" size="default" inline="false" data-orientation="horizontal" fullwidth="true"
+							data-slotendsize="default" data-slotstartsize="default" aria-busy="false" data-completed="false"
+							data-slotend="false" style="pointer-events: auto;"><i _ngcontent-app-c2304148310=""
 								class="button-icon--start"></i> Add to trolley <!----><!----><!----><!----><i
 								_ngcontent-app-c2304148310=""
 								class="button-icon--end"><!----><!----></i></button><!----><!----><!----></product-add-to-trolley>
@@ -2215,7 +2215,120 @@
 						_ngcontent-app-c1464354569="" cdxbutton="" fillstyle="flat" class="product-notes ng-star-inserted"
 						_nghost-app-c2304148310=""
 						aria-label="Add shopper notes related to tegel free range quick cook chicken steaks chargrilled"
-						aria-disabled="false" size="default" inline="false" data-orientation="horizontal"
+						aria-disabled="false" size="default" inline="false" data-orientation="horizontal" fullwidth="false"
+						data-slotendsize="default" data-slotstartsize="default" aria-busy="false" data-completed="false"
+						style="pointer-events: auto;"><i _ngcontent-app-c2304148310="" class="button-icon--start"></i><cdx-svg-icon
+							_ngcontent-app-c1464354569="" fill="green" _nghost-app-c3828805972="" display="block"
+							class="ng-star-inserted"><svg _ngcontent-app-c3828805972="" version="1.1" viewbox="0 0 32 32"
+								xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+								<use _ngcontent-app-c3828805972="" href="#notes-default"></use>
+							</svg></cdx-svg-icon><!----><!----><!----><!----><i _ngcontent-app-c2304148310=""
+							class="button-icon--end"><!----><!----></i></button><!----><!----></div><!----><!----><!---->
+			</product-stamp-grid></cdx-card>
+		<!---->
+		<!---->
+		<!---->
+		<!---->
+		<!---->
+		<!---->
+		<!---->
+		<!---->
+		<!-- FRESH DEAL - 2 for $3 -->
+		<cdx-card _ngcontent-app-c3653078101="" _nghost-app-c3713186528=""
+			class="cdx-card-cup-adjustment card ng-star-inserted" card-padding="default" card-center="false"
+			card-rounded="false"><product-stamp-grid _ngcontent-app-c3653078101="" _nghost-app-c1464354569="" role="article"
+				data-targeted-offer="false"><!----><!----><!----><product-tag _ngcontent-app-c1464354569=""
+					_nghost-app-c4009937532="" data-fixed-size="false" data-targeted-offer="false" data-product-strap="true"
+					class="haystack-edr-changes-enabled new-low-price-enabled ng-star-inserted"><!----><!----><a
+						_ngcontent-app-c4009937532="" tabindex="-1" aria-labelledby="product-281082-promoInfo"
+						href="/shop/productgroup/191557" class="ng-star-inserted">
+						<div _ngcontent-app-c4009937532="" id="product-281082-promoInfo"
+							class="productStrap isFreshDeal ng-star-inserted">
+							<div _ngcontent-app-c4009937532="" class="productStrap-title" aria-label="Fresh Deal.">
+								<!----><!----><!----> Fresh Deal
+							</div><cdx-svg-icon _ngcontent-app-c4009937532="" name="fun-green-arc" class="arcIcon ng-star-inserted"
+								_nghost-app-c3828805972="" display="block"><svg _ngcontent-app-c3828805972="" version="1.1"
+									viewbox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+									<use _ngcontent-app-c3828805972="" href="#fun-green-arc"></use>
+								</svg></cdx-svg-icon><!----><!---->
+							<div _ngcontent-app-c4009937532="" class="productStrap-text" aria-label="2 for $3.00.">2 for $3.00</div>
+						</div><!---->
+					</a><!----><!----></product-tag><!----><product-fuel-tag _ngcontent-app-c1464354569=""
+					_nghost-app-c3672188410="" class="ng-star-inserted"><!----></product-fuel-tag><!---->
+				<div _ngcontent-app-c1464354569="" class="product-entry product-cup ng-star-inserted"><a
+						_ngcontent-app-c1464354569="" routerlink="/shop/productdetails" class="productImage-container"
+						aria-labelledby="product-281082-title product-281082-tag product-281082-price product-281082-save product-281082-promoInfo product-281082-unitPrice product-281082-price-single-unit-average product-281082-unavailable"
+						href="/shop/productdetails?stockcode=281082&amp;name=fresh-vegetable-broccoli-head">
+						<figure _ngcontent-app-c1464354569="" cdxproductimage="" _nghost-app-c4259313796="" size="big">
+							<picture _ngcontent-app-c4259313796="" class="ng-star-inserted">
+								<source _ngcontent-app-c4259313796=""
+									srcset="https://assets.woolworths.com.au/images/2010/281082.jpg?impolicy=wowcdxwbjbx&amp;w=200&amp;h=200"
+									media="(min-width:  640px)" class="ng-star-inserted"><!----><!----><!----><img
+									_ngcontent-app-c4259313796="" loading="lazy"
+									src="https://assets.woolworths.com.au/images/2010/281082.jpg?impolicy=wowcdxwbjbx&amp;w=200&amp;h=200"
+									alt="fresh vegetable broccoli head" aria-labelledby="product-281082-title">
+							</picture><!----><!----><!---->
+						</figure>
+						<div _ngcontent-app-c1464354569="" id="product-281082-tag"><!----><!----><!----><!----><!----></div>
+					</a><a _ngcontent-app-c1464354569="" routerlink="/shop/productdetails" tabindex="-1"
+						href="/shop/productdetails?stockcode=281082&amp;name=fresh-vegetable-broccoli-head">
+						<h3 _ngcontent-app-c1464354569="" id="product-281082-title" aria-label="Fresh Vegetable Broccoli Head."
+							style="font-weight: bold;" class="ng-star-inserted"> fresh vegetable broccoli head <!----></h3>
+						<!----><!---->
+					</a><!---->
+					<div _ngcontent-app-c1464354569="" class="product-meta ng-star-inserted"><product-price-meta-v2
+							_ngcontent-app-c1464354569="" _nghost-app-c905183069="">
+							<div _ngcontent-app-c905183069="" class="priceMeta cupPriceAdjustment" id="product-281082-unitPrice">
+								<div _ngcontent-app-c905183069="" class="cupPriceContainer"><span _ngcontent-app-c905183069=""
+										class="cupPrice ng-star-inserted" aria-label="Unit price $1.75 / 1ea">$1.75 / 1ea <br
+											_ngcontent-app-c905183069=""></span><!----></div><a _ngcontent-app-c905183069=""
+									aria-labelledby="product-281082-promoInfo" href="/shop/productgroup/191557"
+									class="ng-star-inserted"><span _ngcontent-app-c905183069="" class="ng-star-inserted">2 for
+										$3.00</span><!----></a><!----><!----><!----><!---->
+							</div>
+						</product-price-meta-v2><product-price-single-unit-average _ngcontent-app-c1464354569=""
+							_nghost-app-c851620979="">
+							<p _ngcontent-app-c851620979="" class="price-single-unit-text"
+								id="product-281082-price-single-unit-average"> </p>
+						</product-price-single-unit-average></div><!----><product-price _ngcontent-app-c1464354569=""
+						ngclass="product-price-cup-adjustment" _nghost-app-c4290805250=""
+						class="product-price-cup-adjustment ng-star-inserted" data-layout="grid" data-zoom="false">
+						<div _ngcontent-app-c4290805250="" class="priceCupAdjustmentDev ng-star-inserted">
+							<h3 _ngcontent-app-c4290805250="" class="heading--2 presentPrice priceCupAdjustment"
+								id="product-281082-price" aria-label="$1.75 each."> $ <em _ngcontent-app-c4290805250="">1</em><span
+									_ngcontent-app-c4290805250=""> 75 <!----></span></h3>
+						</div><!----><!---->
+						<div _ngcontent-app-c4290805250="" id="product-281082-save" class="ng-star-inserted">
+							<div _ngcontent-app-c4290805250="" class="previousPrice"><!----><!----><!----><!----></div><!---->
+						</div><!----><!---->
+					</product-price><!---->
+				</div>
+				<footer _ngcontent-app-c1464354569="" class="ng-star-inserted"><!----><cdx-notification
+						_ngcontent-app-c1464354569="" iconname="tick-sign" colour="green" _nghost-app-c2653343359=""
+						class="ng-tns-c2653343359-618 ng-trigger ng-trigger-doAnimation ng-star-inserted" aria-live="assertive"
+						data-floating="true" data-colour="green" style="opacity: 0;"><cdx-svg-icon _ngcontent-app-c2653343359=""
+							size="small" _nghost-app-c3828805972="" class="ng-tns-c2653343359-618 ng-star-inserted" display="block"
+							fill="green" style=""><svg _ngcontent-app-c3828805972="" version="1.1" viewbox="0 0 32 32"
+								xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+								<use _ngcontent-app-c3828805972="" href="#tick-sign"></use>
+							</svg></cdx-svg-icon><!---->
+						<p _ngcontent-app-c2653343359="" class="ng-tns-c2653343359-618"> 0 in trolley </p>
+					</cdx-notification><!----><product-add-to-trolley _ngcontent-app-c1464354569="" _nghost-app-c1519492223=""
+						class="ng-tns-c1519492223-617 ng-star-inserted"><button _ngcontent-app-c1519492223=""
+							attr.data-cy="addToTrolleyBtn" cdxbutton="" aria-live="polite"
+							class="addToTrolley-btn--add ng-tns-c1519492223-617 ng-trigger ng-trigger-animation ng-star-inserted"
+							_nghost-app-c2304148310="" aria-label="Add fresh vegetable broccoli head to trolley" aria-disabled="false"
+							align="center" fillstyle="primary" size="default" inline="false" data-orientation="horizontal"
+							fullwidth="true" data-slotendsize="default" data-slotstartsize="default" aria-busy="false"
+							data-completed="false" data-slotend="false" style="pointer-events: auto;"><i _ngcontent-app-c2304148310=""
+								class="button-icon--start"></i> Add to trolley <!----><!----><!----><!----><i
+								_ngcontent-app-c2304148310=""
+								class="button-icon--end"><!----><!----></i></button><!----><!----><!----></product-add-to-trolley>
+				</footer>
+				<div _ngcontent-app-c1464354569="" class="product-secondaryActions ng-star-inserted"><button
+						_ngcontent-app-c1464354569="" cdxbutton="" fillstyle="flat" class="product-notes ng-star-inserted"
+						_nghost-app-c2304148310="" aria-label="Add shopper notes related to fresh vegetable broccoli head"
+						aria-disabled="false" align="center" size="default" inline="false" data-orientation="horizontal"
 						fullwidth="false" data-slotendsize="default" data-slotstartsize="default" aria-busy="false"
 						data-completed="false" style="pointer-events: auto;"><i _ngcontent-app-c2304148310=""
 							class="button-icon--start"></i><cdx-svg-icon _ngcontent-app-c1464354569="" fill="green"
@@ -2233,9 +2346,207 @@
 		<!---->
 		<!---->
 		<!---->
+		<!-- UNITLESS PROMO -->
+		<cdx-card _ngcontent-app-c3653078101="" _nghost-app-c3713186528=""
+			class="cdx-card-cup-adjustment card ng-star-inserted" card-padding="default" card-center="false"
+			card-rounded="false"><product-stamp-grid _ngcontent-app-c3653078101="" _nghost-app-c1464354569="" role="article"
+				data-targeted-offer="false"><!----><!----><!----><product-tag _ngcontent-app-c1464354569=""
+					_nghost-app-c4009937532="" data-fixed-size="false" data-targeted-offer="false" data-product-strap="true"
+					class="haystack-edr-changes-enabled new-low-price-enabled ng-star-inserted"><!----><!---->
+					<div _ngcontent-app-c4009937532="" id="product-705958-promoInfo"
+						class="productStrap isSpecial ng-star-inserted">
+						<div _ngcontent-app-c4009937532="" class="productStrap-title" aria-label="Special.">
+							<!----><!----><!----> Special
+						</div><cdx-svg-icon _ngcontent-app-c4009937532="" name="fun-green-arc" class="arcIcon ng-star-inserted"
+							_nghost-app-c3828805972="" display="block"><svg _ngcontent-app-c3828805972="" version="1.1"
+								viewbox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+								<use _ngcontent-app-c3828805972="" href="#fun-green-arc"></use>
+							</svg></cdx-svg-icon><!----><!---->
+						<div _ngcontent-app-c4009937532="" class="productStrap-text" aria-label="Save $8.99.">Save $8.99
+						</div>
+					</div><!----><!----><!---->
+				</product-tag><!----><product-fuel-tag _ngcontent-app-c1464354569="" _nghost-app-c3672188410=""
+					class="ng-star-inserted"><!----></product-fuel-tag><!---->
+				<div _ngcontent-app-c1464354569="" class="product-entry product-cup ng-star-inserted"><a
+						_ngcontent-app-c1464354569="" routerlink="/shop/productdetails" class="productImage-container"
+						aria-labelledby="product-705958-title product-705958-tag product-705958-price product-705958-save product-705958-promoInfo product-705958-unitPrice product-705958-price-single-unit-average product-705958-unavailable"
+						href="/shop/productdetails?stockcode=705958&amp;name=speights-summit-beer-lager-ultra-low-carb">
+						<figure _ngcontent-app-c1464354569="" cdxproductimage="" _nghost-app-c4259313796="" size="big">
+							<picture _ngcontent-app-c4259313796="" class="ng-star-inserted">
+								<source _ngcontent-app-c4259313796=""
+									srcset="https://assets.woolworths.com.au/images/2010/705958.jpg?impolicy=wowcdxwbjbx&amp;w=200&amp;h=200"
+									media="(min-width:  640px)" class="ng-star-inserted"><!----><!----><!----><img
+									_ngcontent-app-c4259313796="" loading="lazy"
+									src="https://assets.woolworths.com.au/images/2010/705958.jpg?impolicy=wowcdxwbjbx&amp;w=200&amp;h=200"
+									alt="speight's summit beer lager ultra low carb" aria-labelledby="product-705958-title">
+							</picture><!----><!----><!---->
+						</figure>
+						<div _ngcontent-app-c1464354569="" id="product-705958-tag"><!----><!----><!----><!----><!---->
+						</div>
+					</a><a _ngcontent-app-c1464354569="" routerlink="/shop/productdetails" tabindex="-1"
+						href="/shop/productdetails?stockcode=705958&amp;name=speights-summit-beer-lager-ultra-low-carb">
+						<h3 _ngcontent-app-c1464354569="" id="product-705958-title"
+							aria-label="Speight's Summit Beer Lager Ultra Low Carbbottle24x330ml." class="ng-star-inserted"
+							style="font-weight: bold;"> speight's summit beer lager ultra low carb Bottle
+							24x330mL<!----><!----></h3><!----><!---->
+					</a><!---->
+					<div _ngcontent-app-c1464354569="" class="product-meta ng-star-inserted"><product-price-meta-v2
+							_ngcontent-app-c1464354569="" _nghost-app-c905183069="">
+							<div _ngcontent-app-c905183069="" class="priceMeta cupPriceAdjustment" id="product-705958-unitPrice">
+								<div _ngcontent-app-c905183069="" class="cupPriceContainer"><!----></div><!----><!---->
+							</div>
+						</product-price-meta-v2><product-price-single-unit-average _ngcontent-app-c1464354569=""
+							_nghost-app-c851620979="">
+							<p _ngcontent-app-c851620979="" class="price-single-unit-text"
+								id="product-705958-price-single-unit-average"> </p>
+						</product-price-single-unit-average></div><!----><product-price _ngcontent-app-c1464354569=""
+						ngclass="product-price-cup-adjustment" _nghost-app-c4290805250=""
+						class="product-price-cup-adjustment ng-star-inserted" data-layout="grid" data-zoom="false">
+						<div _ngcontent-app-c4290805250="" class="priceCupAdjustmentDev ng-star-inserted">
+							<h3 _ngcontent-app-c4290805250="" class="heading--2 presentPrice price--special priceCupAdjustment"
+								id="product-705958-price" aria-label="$41.00 each."> $ <em _ngcontent-app-c4290805250="">41</em><span
+									_ngcontent-app-c4290805250=""> 00 <!----></span></h3>
+						</div><!----><!---->
+						<div _ngcontent-app-c4290805250="" id="product-705958-save" class="ng-star-inserted">
+							<div _ngcontent-app-c4290805250="" class="previousPrice"><!----><!----><span _ngcontent-app-c4290805250=""
+									class="price price--was ng-star-inserted" aria-label="Was 49.99$">Was $49.99</span><!----><span
+									_ngcontent-app-c4290805250="" class="price price--save ng-star-inserted" aria-label="Save 8.99$">Save
+									$8.99</span><!---->
+							</div><!---->
+						</div><!----><!---->
+					</product-price><!---->
+				</div>
+				<footer _ngcontent-app-c1464354569="" class="ng-star-inserted"><!----><cdx-notification
+						_ngcontent-app-c1464354569="" iconname="tick-sign" colour="green" _nghost-app-c2653343359=""
+						class="ng-tns-c2653343359-10 ng-trigger ng-trigger-doAnimation ng-star-inserted" aria-live="assertive"
+						data-floating="true" data-colour="green" style="opacity: 0;"><cdx-svg-icon _ngcontent-app-c2653343359=""
+							size="small" _nghost-app-c3828805972="" class="ng-tns-c2653343359-10 ng-star-inserted" display="block"
+							fill="green" style=""><svg _ngcontent-app-c3828805972="" version="1.1" viewbox="0 0 32 32"
+								xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+								<use _ngcontent-app-c3828805972="" href="#tick-sign"></use>
+							</svg></cdx-svg-icon><!---->
+						<p _ngcontent-app-c2653343359="" class="ng-tns-c2653343359-10"> 0 in trolley </p>
+					</cdx-notification><!----><product-add-to-trolley _ngcontent-app-c1464354569="" _nghost-app-c1519492223=""
+						class="ng-tns-c1519492223-9 ng-star-inserted"><button _ngcontent-app-c1519492223=""
+							attr.data-cy="addToTrolleyBtn" cdxbutton="" aria-live="polite"
+							class="addToTrolley-btn--add ng-tns-c1519492223-9 ng-trigger ng-trigger-animation ng-star-inserted ng-animating"
+							_nghost-app-c2304148310="" aria-label="Add speight's summit beer lager ultra low carb to trolley"
+							aria-disabled="false" align="center" fillstyle="primary" size="default" inline="false"
+							data-orientation="horizontal" fullwidth="true" data-slotendsize="default" data-slotstartsize="default"
+							aria-busy="false" data-completed="false" data-slotend="false" style="pointer-events: auto;"><i
+								_ngcontent-app-c2304148310="" class="button-icon--start"></i> Add to trolley
+							<!----><!----><!----><!----><i _ngcontent-app-c2304148310=""
+								class="button-icon--end"><!----><!----></i></button><!----><!----><!----></product-add-to-trolley>
+				</footer>
+				<div _ngcontent-app-c1464354569="" class="product-secondaryActions ng-star-inserted"><button
+						_ngcontent-app-c1464354569="" cdxbutton="" fillstyle="flat" class="product-notes ng-star-inserted"
+						_nghost-app-c2304148310=""
+						aria-label="Add shopper notes related to speight's summit beer lager ultra low carb" aria-disabled="false"
+						align="center" size="default" inline="false" data-orientation="horizontal" fullwidth="false"
+						data-slotendsize="default" data-slotstartsize="default" aria-busy="false" data-completed="false"
+						style="pointer-events: auto;"><i _ngcontent-app-c2304148310="" class="button-icon--start"></i><cdx-svg-icon
+							_ngcontent-app-c1464354569="" fill="green" _nghost-app-c3828805972="" display="block"
+							class="ng-star-inserted"><svg _ngcontent-app-c3828805972="" version="1.1" viewbox="0 0 32 32"
+								xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+								<use _ngcontent-app-c3828805972="" href="#notes-default"></use>
+							</svg></cdx-svg-icon><!----><!----><!----><!----><i _ngcontent-app-c2304148310=""
+							class="button-icon--end"><!----><!----></i></button><!----><!----></div><!----><!----><!---->
+			</product-stamp-grid></cdx-card>
 		<!---->
-		<!-- FRESH DEAL - 2 for $3 -->
-			<cdx-card _ngcontent-app-c3653078101="" _nghost-app-c3713186528="" class="cdx-card-cup-adjustment card ng-star-inserted" card-padding="default" card-center="false" card-rounded="false"><product-stamp-grid _ngcontent-app-c3653078101="" _nghost-app-c1464354569="" role="article" data-targeted-offer="false"><!----><!----><!----><product-tag _ngcontent-app-c1464354569="" _nghost-app-c4009937532="" data-fixed-size="false" data-targeted-offer="false" data-product-strap="true" class="haystack-edr-changes-enabled new-low-price-enabled ng-star-inserted"><!----><!----><a _ngcontent-app-c4009937532="" tabindex="-1" aria-labelledby="product-281082-promoInfo" href="/shop/productgroup/191557" class="ng-star-inserted"><div _ngcontent-app-c4009937532="" id="product-281082-promoInfo" class="productStrap isFreshDeal ng-star-inserted"><div _ngcontent-app-c4009937532="" class="productStrap-title" aria-label="Fresh Deal."><!----><!----><!----> Fresh Deal </div><cdx-svg-icon _ngcontent-app-c4009937532="" name="fun-green-arc" class="arcIcon ng-star-inserted" _nghost-app-c3828805972="" display="block"><svg _ngcontent-app-c3828805972="" version="1.1" viewbox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use _ngcontent-app-c3828805972="" href="#fun-green-arc"></use></svg></cdx-svg-icon><!----><!----><div _ngcontent-app-c4009937532="" class="productStrap-text" aria-label="2 for $3.00.">2 for $3.00</div></div><!----></a><!----><!----></product-tag><!----><product-fuel-tag _ngcontent-app-c1464354569="" _nghost-app-c3672188410="" class="ng-star-inserted"><!----></product-fuel-tag><!----><div _ngcontent-app-c1464354569="" class="product-entry product-cup ng-star-inserted"><a _ngcontent-app-c1464354569="" routerlink="/shop/productdetails" class="productImage-container" aria-labelledby="product-281082-title product-281082-tag product-281082-price product-281082-save product-281082-promoInfo product-281082-unitPrice product-281082-price-single-unit-average product-281082-unavailable" href="/shop/productdetails?stockcode=281082&amp;name=fresh-vegetable-broccoli-head"><figure _ngcontent-app-c1464354569="" cdxproductimage="" _nghost-app-c4259313796="" size="big"><picture _ngcontent-app-c4259313796="" class="ng-star-inserted"><source _ngcontent-app-c4259313796="" srcset="https://assets.woolworths.com.au/images/2010/281082.jpg?impolicy=wowcdxwbjbx&amp;w=200&amp;h=200" media="(min-width:  640px)" class="ng-star-inserted"><!----><!----><!----><img _ngcontent-app-c4259313796="" loading="lazy" src="https://assets.woolworths.com.au/images/2010/281082.jpg?impolicy=wowcdxwbjbx&amp;w=200&amp;h=200" alt="fresh vegetable broccoli head" aria-labelledby="product-281082-title"></picture><!----><!----><!----></figure><div _ngcontent-app-c1464354569="" id="product-281082-tag"><!----><!----><!----><!----><!----></div></a><a _ngcontent-app-c1464354569="" routerlink="/shop/productdetails" tabindex="-1" href="/shop/productdetails?stockcode=281082&amp;name=fresh-vegetable-broccoli-head"><h3 _ngcontent-app-c1464354569="" id="product-281082-title" aria-label="Fresh Vegetable Broccoli Head." style="font-weight: bold;" class="ng-star-inserted"> fresh vegetable broccoli head  <!----></h3><!----><!----></a><!----><div _ngcontent-app-c1464354569="" class="product-meta ng-star-inserted"><product-price-meta-v2 _ngcontent-app-c1464354569="" _nghost-app-c905183069=""><div _ngcontent-app-c905183069="" class="priceMeta cupPriceAdjustment" id="product-281082-unitPrice"><div _ngcontent-app-c905183069="" class="cupPriceContainer"><span _ngcontent-app-c905183069="" class="cupPrice ng-star-inserted" aria-label="Unit price $1.75 / 1ea">$1.75 / 1ea <br _ngcontent-app-c905183069=""></span><!----></div><a _ngcontent-app-c905183069="" aria-labelledby="product-281082-promoInfo" href="/shop/productgroup/191557" class="ng-star-inserted"><span _ngcontent-app-c905183069="" class="ng-star-inserted">2 for $3.00</span><!----></a><!----><!----><!----><!----></div></product-price-meta-v2><product-price-single-unit-average _ngcontent-app-c1464354569="" _nghost-app-c851620979=""><p _ngcontent-app-c851620979="" class="price-single-unit-text" id="product-281082-price-single-unit-average">   </p></product-price-single-unit-average></div><!----><product-price _ngcontent-app-c1464354569="" ngclass="product-price-cup-adjustment" _nghost-app-c4290805250="" class="product-price-cup-adjustment ng-star-inserted" data-layout="grid" data-zoom="false"><div _ngcontent-app-c4290805250="" class="priceCupAdjustmentDev ng-star-inserted"><h3 _ngcontent-app-c4290805250="" class="heading--2 presentPrice priceCupAdjustment" id="product-281082-price" aria-label="$1.75 each."> $ <em _ngcontent-app-c4290805250="">1</em><span _ngcontent-app-c4290805250=""> 75 <!----></span></h3></div><!----><!----><div _ngcontent-app-c4290805250="" id="product-281082-save" class="ng-star-inserted"><div _ngcontent-app-c4290805250="" class="previousPrice"><!----><!----><!----><!----></div><!----></div><!----><!----></product-price><!----></div><footer _ngcontent-app-c1464354569="" class="ng-star-inserted"><!----><cdx-notification _ngcontent-app-c1464354569="" iconname="tick-sign" colour="green" _nghost-app-c2653343359="" class="ng-tns-c2653343359-618 ng-trigger ng-trigger-doAnimation ng-star-inserted" aria-live="assertive" data-floating="true" data-colour="green" style="opacity: 0;"><cdx-svg-icon _ngcontent-app-c2653343359="" size="small" _nghost-app-c3828805972="" class="ng-tns-c2653343359-618 ng-star-inserted" display="block" fill="green" style=""><svg _ngcontent-app-c3828805972="" version="1.1" viewbox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use _ngcontent-app-c3828805972="" href="#tick-sign"></use></svg></cdx-svg-icon><!----><p _ngcontent-app-c2653343359="" class="ng-tns-c2653343359-618"> 0 in trolley </p></cdx-notification><!----><product-add-to-trolley _ngcontent-app-c1464354569="" _nghost-app-c1519492223="" class="ng-tns-c1519492223-617 ng-star-inserted"><button _ngcontent-app-c1519492223="" attr.data-cy="addToTrolleyBtn" cdxbutton="" aria-live="polite" class="addToTrolley-btn--add ng-tns-c1519492223-617 ng-trigger ng-trigger-animation ng-star-inserted" _nghost-app-c2304148310="" aria-label="Add fresh vegetable broccoli head to trolley" aria-disabled="false" align="center" fillstyle="primary" size="default" inline="false" data-orientation="horizontal" fullwidth="true" data-slotendsize="default" data-slotstartsize="default" aria-busy="false" data-completed="false" data-slotend="false" style="pointer-events: auto;"><i _ngcontent-app-c2304148310="" class="button-icon--start"></i> Add to trolley <!----><!----><!----><!----><i _ngcontent-app-c2304148310="" class="button-icon--end"><!----><!----></i></button><!----><!----><!----></product-add-to-trolley></footer><div _ngcontent-app-c1464354569="" class="product-secondaryActions ng-star-inserted"><button _ngcontent-app-c1464354569="" cdxbutton="" fillstyle="flat" class="product-notes ng-star-inserted" _nghost-app-c2304148310="" aria-label="Add shopper notes related to fresh vegetable broccoli head" aria-disabled="false" align="center" size="default" inline="false" data-orientation="horizontal" fullwidth="false" data-slotendsize="default" data-slotstartsize="default" aria-busy="false" data-completed="false" style="pointer-events: auto;"><i _ngcontent-app-c2304148310="" class="button-icon--start"></i><cdx-svg-icon _ngcontent-app-c1464354569="" fill="green" _nghost-app-c3828805972="" display="block" class="ng-star-inserted"><svg _ngcontent-app-c3828805972="" version="1.1" viewbox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use _ngcontent-app-c3828805972="" href="#notes-default"></use></svg></cdx-svg-icon><!----><!----><!----><!----><i _ngcontent-app-c2304148310="" class="button-icon--end"><!----><!----></i></button><!----><!----></div><!----><!----><!----></product-stamp-grid></cdx-card>
+		<!---->
+		<!---->
+		<!---->
+		<!---->
+		<!---->
+		<!---->
+		<!-- UNITLESS NORMAL -->
+		<cdx-card _ngcontent-app-c3653078101="" _nghost-app-c3713186528=""
+			class="cdx-card-cup-adjustment card ng-star-inserted" card-padding="default" card-center="false"
+			card-rounded="false"><product-stamp-grid _ngcontent-app-c3653078101="" _nghost-app-c1464354569="" role="article"
+				data-targeted-offer="false"><!----><!----><!----><!----><!---->
+				<div _ngcontent-app-c1464354569="" class="product-entry product-cup ng-star-inserted"><a
+						_ngcontent-app-c1464354569="" routerlink="/shop/productdetails" class="productImage-container"
+						aria-labelledby="product-907038-title product-907038-tag product-907038-price product-907038-save product-907038-promoInfo product-907038-unitPrice product-907038-price-single-unit-average product-907038-unavailable"
+						href="/shop/productdetails?stockcode=907038&amp;name=speights-gold-medal-beer-ale">
+						<figure _ngcontent-app-c1464354569="" cdxproductimage="" _nghost-app-c4259313796="" size="big">
+							<picture _ngcontent-app-c4259313796="" class="ng-star-inserted">
+								<source _ngcontent-app-c4259313796=""
+									srcset="https://assets.woolworths.com.au/images/2010/907038.jpg?impolicy=wowcdxwbjbx&amp;w=200&amp;h=200"
+									media="(min-width:  640px)" class="ng-star-inserted"><!----><!----><!----><img
+									_ngcontent-app-c4259313796="" loading="lazy"
+									src="https://assets.woolworths.com.au/images/2010/907038.jpg?impolicy=wowcdxwbjbx&amp;w=200&amp;h=200"
+									alt="speight's gold medal beer ale" aria-labelledby="product-907038-title">
+							</picture><!----><!----><!---->
+						</figure>
+						<div _ngcontent-app-c1464354569="" id="product-907038-tag"><!----><!----><!----><!----><!---->
+						</div>
+					</a><a _ngcontent-app-c1464354569="" routerlink="/shop/productdetails" tabindex="-1"
+						href="/shop/productdetails?stockcode=907038&amp;name=speights-gold-medal-beer-ale">
+						<h3 _ngcontent-app-c1464354569="" id="product-907038-title"
+							aria-label="Speight's Gold Medal Beer Alebottle24x330ml." class="ng-star-inserted"
+							style="font-weight: bold;"> speight's gold medal beer ale Bottle 24x330mL<!----><!----></h3>
+						<!----><!---->
+					</a><!---->
+					<div _ngcontent-app-c1464354569="" class="product-meta ng-star-inserted"><product-price-meta-v2
+							_ngcontent-app-c1464354569="" _nghost-app-c905183069="">
+							<div _ngcontent-app-c905183069="" class="priceMeta cupPriceAdjustment" id="product-907038-unitPrice">
+								<div _ngcontent-app-c905183069="" class="cupPriceContainer"><!----></div><!----><!---->
+							</div>
+						</product-price-meta-v2><product-price-single-unit-average _ngcontent-app-c1464354569=""
+							_nghost-app-c851620979="">
+							<p _ngcontent-app-c851620979="" class="price-single-unit-text"
+								id="product-907038-price-single-unit-average"> </p>
+						</product-price-single-unit-average></div><!----><product-price _ngcontent-app-c1464354569=""
+						ngclass="product-price-cup-adjustment" _nghost-app-c4290805250=""
+						class="product-price-cup-adjustment ng-star-inserted" data-layout="grid" data-zoom="false">
+						<div _ngcontent-app-c4290805250="" class="priceCupAdjustmentDev ng-star-inserted">
+							<h3 _ngcontent-app-c4290805250="" class="heading--2 presentPrice priceCupAdjustment"
+								id="product-907038-price" aria-label="$48.99 each."> $ <em _ngcontent-app-c4290805250="">48</em><span
+									_ngcontent-app-c4290805250=""> 99 <!----></span>
+							</h3>
+						</div><!----><!---->
+						<div _ngcontent-app-c4290805250="" id="product-907038-save" class="ng-star-inserted">
+							<div _ngcontent-app-c4290805250="" class="previousPrice"><!----><!----><!----><!----></div>
+							<!---->
+						</div><!----><!---->
+					</product-price><!---->
+				</div>
+				<footer _ngcontent-app-c1464354569="" class="ng-star-inserted"><!----><cdx-notification
+						_ngcontent-app-c1464354569="" iconname="tick-sign" colour="green" _nghost-app-c2653343359=""
+						class="ng-tns-c2653343359-12 ng-trigger ng-trigger-doAnimation ng-star-inserted" aria-live="assertive"
+						data-floating="true" data-colour="green" style="opacity: 0;"><cdx-svg-icon _ngcontent-app-c2653343359=""
+							size="small" _nghost-app-c3828805972="" class="ng-tns-c2653343359-12 ng-star-inserted" display="block"
+							fill="green" style=""><svg _ngcontent-app-c3828805972="" version="1.1" viewbox="0 0 32 32"
+								xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+								<use _ngcontent-app-c3828805972="" href="#tick-sign"></use>
+							</svg></cdx-svg-icon><!---->
+						<p _ngcontent-app-c2653343359="" class="ng-tns-c2653343359-12"> 0 in trolley </p>
+					</cdx-notification><!----><product-add-to-trolley _ngcontent-app-c1464354569="" _nghost-app-c1519492223=""
+						class="ng-tns-c1519492223-11 ng-star-inserted"><button _ngcontent-app-c1519492223=""
+							attr.data-cy="addToTrolleyBtn" cdxbutton="" aria-live="polite"
+							class="addToTrolley-btn--add ng-tns-c1519492223-11 ng-trigger ng-trigger-animation ng-star-inserted ng-animating"
+							_nghost-app-c2304148310="" aria-label="Add speight's gold medal beer ale to trolley" aria-disabled="false"
+							align="center" fillstyle="primary" size="default" inline="false" data-orientation="horizontal"
+							fullwidth="true" data-slotendsize="default" data-slotstartsize="default" aria-busy="false"
+							data-completed="false" data-slotend="false" style="pointer-events: auto;"><i _ngcontent-app-c2304148310=""
+								class="button-icon--start"></i>
+							Add to trolley <!----><!----><!----><!----><i _ngcontent-app-c2304148310=""
+								class="button-icon--end"><!----><!----></i></button><!----><!----><!----></product-add-to-trolley>
+				</footer>
+				<div _ngcontent-app-c1464354569="" class="product-secondaryActions ng-star-inserted"><button
+						_ngcontent-app-c1464354569="" cdxbutton="" fillstyle="flat" class="product-notes ng-star-inserted"
+						_nghost-app-c2304148310="" aria-label="Add shopper notes related to speight's gold medal beer ale"
+						aria-disabled="false" align="center" size="default" inline="false" data-orientation="horizontal"
+						fullwidth="false" data-slotendsize="default" data-slotstartsize="default" aria-busy="false"
+						data-completed="false" style="pointer-events: auto;"><i _ngcontent-app-c2304148310=""
+							class="button-icon--start"></i><cdx-svg-icon _ngcontent-app-c1464354569="" fill="green"
+							_nghost-app-c3828805972="" display="block" class="ng-star-inserted"><svg _ngcontent-app-c3828805972=""
+								version="1.1" viewbox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"
+								xmlns:xlink="http://www.w3.org/1999/xlink">
+								<use _ngcontent-app-c3828805972="" href="#notes-default"></use>
+							</svg></cdx-svg-icon><!----><!----><!----><!----><i _ngcontent-app-c2304148310=""
+							class="button-icon--end"><!----><!----></i></button><!----><!----></div><!----><!----><!---->
+			</product-stamp-grid></cdx-card><!----><!----><!----><!----><!----><!----><!----><!----><!----><!---->
 	</product-grid>
 </body>
 

--- a/backend/spec/fixtures/wls_curated.json
+++ b/backend/spec/fixtures/wls_curated.json
@@ -165,6 +165,40 @@
         "unit": null,
         "unitPrice": null
       }
+    },
+    {
+      "supermarket": "wls",
+      "id": "705958",
+      "title": "speight's summit beer lager ultra low carb Bottle 24x330mL",
+      "image": "https://assets.woolworths.com.au/images/2010/705958.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
+      "productPageUrl": "https://www.woolworths.co.nz/shop/productdetails?stockcode=705958&name=speights-summit-beer-lager-ultra-low-carb",
+      "price": {
+        "value": "49.99",
+        "per": "ea",
+        "unitPrice": null,
+        "unit": null
+      },
+      "promo": {
+        "tag": "Special",
+        "value": "41.00",
+        "per": "ea",
+        "unitPrice": null,
+        "unit": null
+      }
+    },
+    {
+      "supermarket": "wls",
+      "id": "907038",
+      "title": "speight's gold medal beer ale Bottle 24x330mL",
+      "image": "https://assets.woolworths.com.au/images/2010/907038.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
+      "productPageUrl": "https://www.woolworths.co.nz/shop/productdetails?stockcode=907038&name=speights-gold-medal-beer-ale",
+      "price": {
+        "value": "48.99",
+        "per": "ea",
+        "unitPrice": null,
+        "unit": null
+      },
+      "promo": null
     }
   ]
 }

--- a/backend/spec/fixtures/wls_curated.json
+++ b/backend/spec/fixtures/wls_curated.json
@@ -7,7 +7,6 @@
       "supermarket": "wls",
       "id": "139864",
       "title": "v vitalise energy drink guarana Single can 250mL",
-      "amt": "250mL",
       "image": "https://assets.woolworths.com.au/images/2010/139864.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
       "productPageUrl": "https://www.woolworths.co.nz/shop/productdetails?stockcode=139864&name=v-vitalise-energy-drink-guarana",
       "price": {
@@ -28,7 +27,6 @@
       "supermarket": "wls",
       "id": "132815",
       "title": "v vitalise energy drink 250ml Can 4pack",
-      "amt": "250ml",
       "image": "https://assets.woolworths.com.au/images/2010/132815.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
       "productPageUrl": "https://www.woolworths.co.nz/shop/productdetails?stockcode=132815&name=v-vitalise-energy-drink-250ml",
       "price": {
@@ -43,7 +41,6 @@
       "supermarket": "wls",
       "id": "315692",
       "title": "v vitalise energy drink Single can 500mL",
-      "amt": "500mL",
       "image": "https://assets.woolworths.com.au/images/2010/315692.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
       "productPageUrl": "https://www.woolworths.co.nz/shop/productdetails?stockcode=315692&name=v-vitalise-energy-drink",
       "price": {
@@ -64,7 +61,6 @@
       "supermarket": "wls",
       "id": "98508",
       "title": "turks free range chicken breast skinless fillet 450g",
-      "amt": "450g",
       "image": "https://assets.woolworths.com.au/images/2010/98508.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
       "productPageUrl": "https://www.woolworths.co.nz/shop/productdetails?stockcode=98508&name=turks-free-range-chicken-breast-skinless-fillet",
       "price": {
@@ -81,7 +77,6 @@
       "supermarket": "wls",
       "id": "344618",
       "title": "woolworths chicken whole Each 1.35kg",
-      "amt": "1.35kg",
       "image": "https://assets.woolworths.com.au/images/2010/344618.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
       "productPageUrl": "https://www.woolworths.co.nz/shop/productdetails?stockcode=344618&name=woolworths-chicken-whole",
       "price": {
@@ -101,7 +96,6 @@
       "supermarket": "wls",
       "id": "363271",
       "title": "tegel meal maker free range shredded roast chicken 100g 2 x 50g pks",
-      "amt": "100g",
       "image": "https://assets.woolworths.com.au/images/2010/363271.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
       "productPageUrl": "https://www.woolworths.co.nz/shop/productdetails?stockcode=363271&name=tegel-meal-maker-free-range-shredded-roast-chicken",
       "price": {
@@ -122,7 +116,6 @@
       "supermarket": "wls",
       "id": "251463",
       "title": "woolworths NZ chicken mince breast 3% fat barn raised Tray 400g",
-      "amt": "400g",
       "image": "https://assets.woolworths.com.au/images/2010/251463.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
       "productPageUrl": "https://www.woolworths.co.nz/shop/productdetails?stockcode=251463&name=woolworths-nz-chicken-mince-breast-3-fat-barn-raised",
       "price": {
@@ -142,7 +135,6 @@
       "supermarket": "wls",
       "id": "6014370",
       "title": "tegel free range quick cook chicken steaks chargrilled 4pk 400g",
-      "amt": "400g",
       "image": "https://assets.woolworths.com.au/images/2010/6014370.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
       "productPageUrl": "https://www.woolworths.co.nz/shop/productdetails?stockcode=6014370&name=tegel-free-range-quick-cook-chicken-steaks-chargrilled",
       "price": {
@@ -159,7 +151,6 @@
       "supermarket": "wls",
       "id": "281082",
       "title": "fresh vegetable broccoli head",
-      "amt": null,
       "image": "https://assets.woolworths.com.au/images/2010/281082.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
       "productPageUrl": "https://www.woolworths.co.nz/shop/productdetails?stockcode=281082&name=fresh-vegetable-broccoli-head",
       "price": {

--- a/backend/spec/services/paknsave_parser_spec.rb
+++ b/backend/spec/services/paknsave_parser_spec.rb
@@ -6,6 +6,8 @@ PNS_DEAL_TYPES = [
   "Multibuy",
   "Limit",
   "Extra Low",
+  "Unitless",
+  "Unitless Promo",
 ]
 
 RSpec.describe PaknsaveParser do
@@ -48,10 +50,28 @@ RSpec.describe PaknsaveParser do
       end
 
       it "correctly formats product type: Normal" do
-        normal_product = @actual_products.find { |deal| !deal[:promo] }
+        normal_product = @actual_products.find { |deal| !deal[:promo] && deal[:price][:unit] }
         expect(normal_product[:id]).to eq(MockTestData::PNS_NORMAL_OBJ[:id])
         expect(normal_product[:title]).to eq(MockTestData::PNS_NORMAL_OBJ[:title])
         expect(normal_product[:promo]).to eq(nil)
+      end
+
+      it "correctly formats product type: Normal products with no unit/unitPrice" do
+        unitless_product = @actual_products.find { |deal| deal[:price][:unit].nil? && deal[:promo].nil? }
+        expect(unitless_product[:id]).to eq(MockTestData::PNS_UNITLESS_OBJ[:id])
+        expect(unitless_product[:title]).to eq(MockTestData::PNS_UNITLESS_OBJ[:title])
+        expect(unitless_product[:price][:unitPrice]).to eq(nil)
+        expect(unitless_product[:price][:unit]).to eq(nil)
+        expect(unitless_product[:promo]).to eq(nil)
+      end
+
+      it "correctly formats product type: Promo products with no unit/unitPrice" do
+        unitless_promo_product = @actual_products.find { |deal| deal[:price][:unit].nil? && deal[:promo] }
+        expect(unitless_promo_product[:id]).to eq(MockTestData::PNS_UNITLESS_OBJ_PROMO[:id])
+        expect(unitless_promo_product[:title]).to eq(MockTestData::PNS_UNITLESS_OBJ_PROMO[:title])
+        expect(unitless_promo_product[:price][:unitPrice]).to eq(nil)
+        expect(unitless_promo_product[:price][:unit]).to eq(nil)
+        expect(unitless_promo_product[:promo][:tag]).to eq("Extra Low")
       end
 
       it "correctly returns all data" do

--- a/backend/spec/services/woolworths_parser_spec.rb
+++ b/backend/spec/services/woolworths_parser_spec.rb
@@ -10,6 +10,8 @@ DEAL_TYPES = [
   "Low Price w Multi-Buy",
   "Disney Disc",
   "Fresh Deal Multi-Buy",
+  "Unitless Promo",
+  "Unitless Normal",
 ]
 
 RSpec.describe WoolworthsParser do

--- a/frontend/src/types/Price.types.d.ts
+++ b/frontend/src/types/Price.types.d.ts
@@ -1,6 +1,6 @@
 type Price = {
   value: string;
-  per?: string;
-  unitPrice: string;
-  unit: string;
+  per: string;
+  unitPrice: string | null;
+  unit: string | null;
 };

--- a/frontend/src/types/Product.types.d.ts
+++ b/frontend/src/types/Product.types.d.ts
@@ -1,4 +1,5 @@
 type Product = {
+  supermarket: ShopCode;
   id: string;
   title: string;
   image: string;
@@ -6,3 +7,5 @@ type Product = {
   price: Price;
   promo: Promo | null;
 };
+
+type ShopCode = "nw" | "pns" | "wls";


### PR DESCRIPTION
<!-- Description of task purpose -->
Updates are needed to ensure the behaviour of the different parsers are similar and produce the same shaped data

Project ticket: #110 

### Acceptance Criteria
- [x] The front end types match the final data structure
- [x] `productPageUrl` keys consistently use domain + path vs just path
- [x] `amt` should be part of `title`

### Discoveries
<!-- Anything to note/for others' understanding -->
Within PR is an update to Dockerfile to freeze the environment into the last good image, may be some other updates to keep the current image but will need to change Dockerfile to install yarn differently, as the newest docker image doesn't install yarn the same way. This is a potential fix but will be a decision for another ticket
<img width="699" height="601" alt="Screenshot 2025-08-13 124935" src="https://github.com/user-attachments/assets/2a164be1-f69b-43b7-97fa-241b495aeb90" />


### Testing
<!-- Notes on how to manual test, evidence of added tests passing with 80% coverage etc -->
Tests for woolworths and paknsave have been updated to include products that have no `unit` or `unitPrice`

<img width="714" height="961" alt="Screenshot 2025-08-13 130958" src="https://github.com/user-attachments/assets/95a476ba-22b4-409a-8253-443d22281016" />


### Checklist
- [x] tests passing
- [x] applied relevant labels to PR ***(`chore`/`feat`/`fix` etc)***
- [x] added screenshots/recordings ***(if applicable)***


### Screenshots/Recordings ***(optional)***
