### PR TITLE
update cart item quantity

### DIFF
--- a/frontend/src/context/CartContext.test.tsx
+++ b/frontend/src/context/CartContext.test.tsx
@@ -1,7 +1,15 @@
 import { act, renderHook } from "@testing-library/react";
 import { expect, vi } from "vitest";
 
-import { fullProductDetails, preexistingCart } from "@/lib/test/fixtures/cart";
+import {
+  cartWithSingleItem,
+  emptyCart,
+  fullCart,
+  fullProductDetails,
+  partialCart,
+  partialCart_itemRemoved,
+  partialCart_quantityUpdated,
+} from "@/lib/test/fixtures/cart";
 
 import { useCart } from "./CartContext";
 import { setLocalData } from "./utils/localStorage";
@@ -19,7 +27,7 @@ describe("Given a user has an empty cart", () => {
     it("Then the cart contains that item under the correct supermarket", () => {
       const testProduct = {
         ...fullProductDetails,
-        id: "test_product_1",
+        id: "3330159",
         title: "Shampoo",
       };
 
@@ -28,7 +36,7 @@ describe("Given a user has an empty cart", () => {
         result.current.addCartItem("wls", testProduct);
       });
 
-      const itemInCart = result.current.cart.wls.test_product_1;
+      const itemInCart = result.current.cart.wls["3330159"];
 
       expect(itemInCart).toBeDefined();
       expect(itemInCart.product.title).toBe("Shampoo");
@@ -37,8 +45,7 @@ describe("Given a user has an empty cart", () => {
     it("Then the quantity of the new item is set to 1", () => {
       const testProduct = {
         ...fullProductDetails,
-        id: "test_product_2",
-        title: "Cake",
+        id: "2220732",
       };
 
       const { result } = renderComponentWithCart();
@@ -46,7 +53,7 @@ describe("Given a user has an empty cart", () => {
         result.current.addCartItem("pns", testProduct);
       });
 
-      const itemInCart = result.current.cart.pns.test_product_2;
+      const itemInCart = result.current.cart.pns["2220732"];
 
       expect(itemInCart).toBeDefined();
       expect(itemInCart.quantity).toBe(1);
@@ -55,8 +62,7 @@ describe("Given a user has an empty cart", () => {
     it("Then there is only that item in the cart", () => {
       const testProduct = {
         ...fullProductDetails,
-        id: "test_product_3",
-        title: "Flour",
+        id: "1110000",
       };
 
       const { result } = renderComponentWithCart();
@@ -64,42 +70,31 @@ describe("Given a user has an empty cart", () => {
         result.current.addCartItem("nw", testProduct);
       });
 
-      expect(result.current.cart).toEqual({
-        nw: {
-          test_product_3: {
-            product: testProduct,
-            quantity: 1,
-          },
-        },
-        pns: {},
-        wls: {},
-      });
+      expect(result.current.cart).toEqual(cartWithSingleItem);
     });
   });
 });
 
 describe("Given a user already has items in their cart", () => {
   describe("When the user clears their cart", () => {
-    it("Then all supermarkets show no items", () => {
-      const { result } = renderComponentWithCart(preexistingCart);
+    it("Then all supermarkets have no items", () => {
+      const { result } = renderComponentWithCart(fullCart);
       act(() => {
         result.current.clearCart();
       });
 
-      expect(result.current.cart).toEqual({
-        nw: {},
-        pns: {},
-        wls: {},
-      });
+      expect(result.current.cart.nw).toEqual({});
+      expect(result.current.cart.pns).toEqual({});
+      expect(result.current.cart.wls).toEqual({});
     });
   });
 
   describe("When the user adds a new item to their cart", () => {
     it("Then the item is added to the correct supermarket", () => {
-      const { result } = renderComponentWithCart(preexistingCart);
+      const { result } = renderComponentWithCart(partialCart);
       const testProduct = {
         ...fullProductDetails,
-        id: "new_item_1",
+        id: "1110548",
         title: "Broccoli",
       };
 
@@ -107,17 +102,17 @@ describe("Given a user already has items in their cart", () => {
         result.current.addCartItem("nw", testProduct);
       });
 
-      const itemInCart = result.current.cart.nw.new_item_1;
+      const itemInCart = result.current.cart.nw["1110548"];
 
       expect(itemInCart).toBeDefined();
       expect(itemInCart.product).toEqual(testProduct);
     });
 
     it("Then the quantity of the new item is set to 1", () => {
-      const { result } = renderComponentWithCart(preexistingCart);
+      const { result } = renderComponentWithCart(partialCart);
       const testProduct = {
         ...fullProductDetails,
-        id: "new_item_2",
+        id: "2220489",
         title: "Carrot",
       };
 
@@ -125,7 +120,7 @@ describe("Given a user already has items in their cart", () => {
         result.current.addCartItem("pns", testProduct);
       });
 
-      const itemInCart = result.current.cart.pns.new_item_2;
+      const itemInCart = result.current.cart.pns["2220489"];
 
       expect(itemInCart).toBeDefined();
       expect(itemInCart.product).toEqual(testProduct);
@@ -135,121 +130,85 @@ describe("Given a user already has items in their cart", () => {
 
   describe("When the user adds an item that already exists in their cart", () => {
     it("Then the quantity of the existing item is increased by 1", () => {
-      const { result } = renderComponentWithCart(preexistingCart);
+      const { result } = renderComponentWithCart(partialCart);
 
-      const existingItem = result.current.cart.nw.nw1;
+      const existingItem = result.current.cart.nw["1110001"];
       expect(existingItem.quantity).toBe(5);
 
       act(() => {
         result.current.addCartItem("nw", existingItem.product);
       });
 
-      const updatedItem = result.current.cart.nw.nw1;
+      const updatedItem = result.current.cart.nw["1110001"];
       expect(updatedItem.quantity).toBe(6);
     });
   });
 
   describe("When the user deletes an item from their cart", () => {
     it("Then the item is removed from the correct supermarket", () => {
-      const { result } = renderComponentWithCart(preexistingCart);
-      expect(result.current.cart.nw.nw1).toBeDefined();
+      const { result } = renderComponentWithCart(partialCart);
+      expect(result.current.cart.nw["1110001"]).toBeDefined();
 
       act(() => {
-        result.current.removeCartItem("nw", "nw1");
+        result.current.removeCartItem("nw", "1110001");
       });
 
-      expect(result.current.cart.nw.nw1).toBeUndefined();
+      expect(result.current.cart.nw["1110001"]).toBeUndefined();
       expect(result.current.cart.nw).toEqual({});
     });
 
     it("Then only that item is removed from the cart", () => {
-      const { result } = renderComponentWithCart(preexistingCart);
+      const { result } = renderComponentWithCart(partialCart);
       act(() => {
-        result.current.removeCartItem("pns", "pns1");
+        result.current.removeCartItem("pns", "2220001");
       });
 
-      expect(result.current.cart).toEqual({
-        nw: {
-          nw1: {
-            product: {
-              ...fullProductDetails,
-              id: "nw1",
-            },
-            quantity: 5,
-          },
-        },
-        pns: {
-          pns2: {
-            product: {
-              ...fullProductDetails,
-              id: "pns2",
-            },
-            quantity: 1,
-          },
-        },
-        wls: {},
-      });
+      expect(result.current.cart).toEqual(partialCart_itemRemoved);
     });
   });
 
   describe("When the user updates the item quantity", () => {
     it("Then the item quantity is updated in the cart", () => {
-      const { result } = renderComponentWithCart(preexistingCart);
+      const { result } = renderComponentWithCart(partialCart);
       act(() => {
-        result.current.updateCartItemQuantity("pns", "pns2", 10);
+        result.current.updateCartItemQuantity("pns", "2220002", 10);
       });
 
-      const updatedItem = result.current.cart.pns.pns2;
+      const updatedItem = result.current.cart.pns["2220002"];
       expect(updatedItem.quantity).toBe(10);
     });
 
     it("Then only that item quantity is updated", () => {
-      const { result } = renderComponentWithCart(preexistingCart);
+      const { result } = renderComponentWithCart(partialCart);
       act(() => {
-        result.current.updateCartItemQuantity("pns", "pns1", 3);
+        result.current.updateCartItemQuantity("pns", "2220001", 300);
       });
 
-      expect(result.current.cart.pns.pns1.quantity).toBe(3);
+      expect(result.current.cart.pns["2220001"].quantity).toBe(300);
 
-      expect(result.current.cart).toEqual({
-        nw: {
-          nw1: {
-            product: {
-              ...fullProductDetails,
-              id: "nw1",
-            },
-            quantity: 5,
-          },
-        },
-        pns: {
-          pns1: {
-            product: {
-              ...fullProductDetails,
-              id: "pns1",
-            },
-            quantity: 3,
-          },
-          pns2: {
-            product: {
-              ...fullProductDetails,
-              id: "pns2",
-            },
-            quantity: 1,
-          },
-        },
-        wls: {},
-      });
+      expect(result.current.cart).toEqual(partialCart_quantityUpdated);
     });
+  });
 
-    it("Then the item is removed if the quantity is set to 0", () => {
-      const { result } = renderComponentWithCart(preexistingCart);
+  describe("When the user sets the item quantity to 0", () => {
+    it("Then the item is removed", () => {
+      const { result } = renderComponentWithCart(partialCart);
       act(() => {
-        result.current.updateCartItemQuantity("nw", "nw1", 0);
+        result.current.updateCartItemQuantity("nw", "1110001", 0);
       });
 
-      const removedItem = result.current.cart.nw.nw1;
+      const removedItem = result.current.cart.nw["1110001"];
       expect(removedItem).toBeUndefined();
       expect(result.current.cart.nw).toEqual({});
+    });
+
+    it("Then only that item is removed from the cart", () => {
+      const { result } = renderComponentWithCart(partialCart);
+      act(() => {
+        result.current.updateCartItemQuantity("pns", "2220001", 0);
+      });
+
+      expect(result.current.cart).toEqual(partialCart_itemRemoved);
     });
   });
 });
@@ -264,16 +223,12 @@ describe("Given a user has not been to the site before", () => {
   describe("When the user visits the site for the first time", () => {
     it("Then an empty cart is loaded up", () => {
       const { result } = renderComponentWithCart(null);
-      expect(result.current.cart).toEqual({ nw: {}, pns: {}, wls: {} });
+      expect(result.current.cart).toEqual(emptyCart);
     });
 
     it("Then an empty cart is saved for next time", () => {
       renderComponentWithCart(null);
-      expect(setLocalData).toHaveBeenCalledWith("cart", {
-        nw: {},
-        pns: {},
-        wls: {},
-      });
+      expect(setLocalData).toHaveBeenCalledWith("cart", emptyCart);
     });
   });
 });
@@ -281,8 +236,8 @@ describe("Given a user has not been to the site before", () => {
 describe("Given a user has previously been to the site", () => {
   describe("When the user loads up the site", () => {
     it("Then their cart is restored to its previous state", () => {
-      const { result } = renderComponentWithCart(preexistingCart);
-      expect(result.current.cart).toEqual(preexistingCart);
+      const { result } = renderComponentWithCart(fullCart);
+      expect(result.current.cart).toEqual(fullCart);
     });
   });
 });
@@ -296,11 +251,7 @@ describe("Given a user changes their cart", () => {
     it("Then the changes are saved for the next visit", () => {
       const { result } = renderComponentWithCart();
       expect(setLocalData).toHaveBeenCalledTimes(1);
-      expect(setLocalData).toHaveBeenCalledWith("cart", {
-        nw: {},
-        pns: {},
-        wls: {},
-      });
+      expect(setLocalData).toHaveBeenCalledWith("cart", emptyCart);
 
       act(() => {
         result.current.addCartItem("nw", fullProductDetails);

--- a/frontend/src/context/CartContext.test.tsx
+++ b/frontend/src/context/CartContext.test.tsx
@@ -133,6 +133,22 @@ describe("Given a user already has items in their cart", () => {
     });
   });
 
+  describe("When they add an item that already exists in their cart", () => {
+    it("Then the quantity of the item is increased", () => {
+      const { result } = renderComponentWithCart(preexistingCart);
+
+      const existingItem = result.current.cart.nw.nw1;
+      expect(existingItem.quantity).toBe(5);
+
+      act(() => {
+        result.current.addCartItem("nw", existingItem.product);
+      });
+
+      const updatedItem = result.current.cart.nw.nw1;
+      expect(updatedItem.quantity).toBe(6);
+    });
+  });
+
   describe("When they delete an item from their cart", () => {
     it("Then the item is removed from the correct supermarket", () => {
       const { result } = renderComponentWithCart(preexistingCart);
@@ -155,18 +171,85 @@ describe("Given a user already has items in their cart", () => {
       expect(result.current.cart).toEqual({
         nw: {
           nw1: {
-            product: fullProductDetails,
+            product: {
+              ...fullProductDetails,
+              id: "nw1",
+            },
             quantity: 5,
           },
         },
         pns: {
           pns2: {
-            product: fullProductDetails,
+            product: {
+              ...fullProductDetails,
+              id: "pns2",
+            },
             quantity: 1,
           },
         },
         wls: {},
       });
+    });
+  });
+
+  describe("When they update the item quantity", () => {
+    it("Then the item quantity is updated in the cart", () => {
+      const { result } = renderComponentWithCart(preexistingCart);
+      act(() => {
+        result.current.updateCartItemQuantity("pns", "pns2", 10);
+      });
+
+      const updatedItem = result.current.cart.pns.pns2;
+      expect(updatedItem.quantity).toBe(10);
+    });
+
+    it("Then only that item quantity is updated", () => {
+      const { result } = renderComponentWithCart(preexistingCart);
+      act(() => {
+        result.current.updateCartItemQuantity("pns", "pns1", 3);
+      });
+
+      expect(result.current.cart.pns.pns1.quantity).toBe(3);
+
+      expect(result.current.cart).toEqual({
+        nw: {
+          nw1: {
+            product: {
+              ...fullProductDetails,
+              id: "nw1",
+            },
+            quantity: 5,
+          },
+        },
+        pns: {
+          pns1: {
+            product: {
+              ...fullProductDetails,
+              id: "pns1",
+            },
+            quantity: 3,
+          },
+          pns2: {
+            product: {
+              ...fullProductDetails,
+              id: "pns2",
+            },
+            quantity: 1,
+          },
+        },
+        wls: {},
+      });
+    });
+
+    it("Then the item is removed if the quantity is set to 0", () => {
+      const { result } = renderComponentWithCart(preexistingCart);
+      act(() => {
+        result.current.updateCartItemQuantity("nw", "nw1", 0);
+      });
+
+      const removedItem = result.current.cart.nw.nw1;
+      expect(removedItem).toBeUndefined();
+      expect(result.current.cart.nw).toEqual({});
     });
   });
 });

--- a/frontend/src/context/CartContext.test.tsx
+++ b/frontend/src/context/CartContext.test.tsx
@@ -15,8 +15,8 @@ vi.mock("./utils/localStorage", () => ({
 // ----- USER INTERACTIONS -----
 
 describe("Given a user has an empty cart", () => {
-  describe("When they add an item from a specific supermarket", () => {
-    it("Then the cart contains that item under the supermarket they selected", () => {
+  describe("When the user adds an item from a specific supermarket", () => {
+    it("Then the cart contains that item under the correct supermarket", () => {
       const testProduct = {
         ...fullProductDetails,
         id: "test_product_1",
@@ -79,7 +79,7 @@ describe("Given a user has an empty cart", () => {
 });
 
 describe("Given a user already has items in their cart", () => {
-  describe("When they clear their cart", () => {
+  describe("When the user clears their cart", () => {
     it("Then all supermarkets show no items", () => {
       const { result } = renderComponentWithCart(preexistingCart);
       act(() => {
@@ -94,7 +94,7 @@ describe("Given a user already has items in their cart", () => {
     });
   });
 
-  describe("When they add a new item to their cart", () => {
+  describe("When the user adds a new item to their cart", () => {
     it("Then the item is added to the correct supermarket", () => {
       const { result } = renderComponentWithCart(preexistingCart);
       const testProduct = {
@@ -133,8 +133,8 @@ describe("Given a user already has items in their cart", () => {
     });
   });
 
-  describe("When they add an item that already exists in their cart", () => {
-    it("Then the quantity of the item is increased", () => {
+  describe("When the user adds an item that already exists in their cart", () => {
+    it("Then the quantity of the existing item is increased by 1", () => {
       const { result } = renderComponentWithCart(preexistingCart);
 
       const existingItem = result.current.cart.nw.nw1;
@@ -149,7 +149,7 @@ describe("Given a user already has items in their cart", () => {
     });
   });
 
-  describe("When they delete an item from their cart", () => {
+  describe("When the user deletes an item from their cart", () => {
     it("Then the item is removed from the correct supermarket", () => {
       const { result } = renderComponentWithCart(preexistingCart);
       expect(result.current.cart.nw.nw1).toBeDefined();
@@ -192,7 +192,7 @@ describe("Given a user already has items in their cart", () => {
     });
   });
 
-  describe("When they update the item quantity", () => {
+  describe("When the user updates the item quantity", () => {
     it("Then the item quantity is updated in the cart", () => {
       const { result } = renderComponentWithCart(preexistingCart);
       act(() => {
@@ -261,7 +261,7 @@ describe("Given a user has not been to the site before", () => {
     vi.clearAllMocks();
   });
 
-  describe("When they visit the site for the first time", () => {
+  describe("When the user visits the site for the first time", () => {
     it("Then an empty cart is loaded up", () => {
       const { result } = renderComponentWithCart(null);
       expect(result.current.cart).toEqual({ nw: {}, pns: {}, wls: {} });
@@ -279,7 +279,7 @@ describe("Given a user has not been to the site before", () => {
 });
 
 describe("Given a user has previously been to the site", () => {
-  describe("When they load up the site", () => {
+  describe("When the user loads up the site", () => {
     it("Then their cart is restored to its previous state", () => {
       const { result } = renderComponentWithCart(preexistingCart);
       expect(result.current.cart).toEqual(preexistingCart);

--- a/frontend/src/context/CartContext.tsx
+++ b/frontend/src/context/CartContext.tsx
@@ -18,6 +18,11 @@ type CartContextType = {
   addCartItem: (supermarket: ShopCode, item: Product) => void;
   clearCart: () => void;
   removeCartItem: (supermarket: ShopCode, itemId: string) => void;
+  updateCartItemQuantity: (
+    supermarket: ShopCode,
+    itemId: string,
+    quantity: number,
+  ) => void;
 };
 
 const CartContext = createContext<CartContextType | undefined>(undefined);
@@ -35,6 +40,12 @@ export const CartProvider = ({ children }: { children: ReactNode }) => {
   };
 
   const addCartItem = (supermarket: ShopCode, item: Product) => {
+    const existingItem = cart[supermarket][item.id];
+    if (existingItem) {
+      updateCartItemQuantity(supermarket, item.id, existingItem.quantity + 1);
+      return;
+    }
+
     setCart((currentCart) => {
       return {
         ...currentCart,
@@ -57,9 +68,37 @@ export const CartProvider = ({ children }: { children: ReactNode }) => {
     });
   };
 
+  const updateCartItemQuantity = (
+    supermarket: ShopCode,
+    itemId: string,
+    quantity: number,
+  ) => {
+    if (quantity === 0) {
+      removeCartItem(supermarket, itemId);
+      return;
+    }
+    if (!cart[supermarket][itemId]) return;
+
+    setCart((currentCart) => {
+      const supermarketCopy = { ...currentCart[supermarket] };
+      const newItemInstance = { ...supermarketCopy[itemId] };
+      newItemInstance.quantity = quantity;
+      return {
+        ...currentCart,
+        [supermarket]: { ...supermarketCopy, [itemId]: newItemInstance },
+      };
+    });
+  };
+
   return (
     <CartContext.Provider
-      value={{ cart, addCartItem, clearCart, removeCartItem }}
+      value={{
+        cart,
+        addCartItem,
+        clearCart,
+        removeCartItem,
+        updateCartItemQuantity,
+      }}
     >
       {children}
     </CartContext.Provider>

--- a/frontend/src/lib/test/fixtures/cart.ts
+++ b/frontend/src/lib/test/fixtures/cart.ts
@@ -15,17 +15,26 @@ export const fullProductDetails = {
 export const preexistingCart = {
   nw: {
     nw1: {
-      product: fullProductDetails,
+      product: {
+        ...fullProductDetails,
+        id: "nw1",
+      },
       quantity: 5,
     },
   },
   pns: {
     pns1: {
-      product: fullProductDetails,
+      product: {
+        ...fullProductDetails,
+        id: "pns1",
+      },
       quantity: 12,
     },
     pns2: {
-      product: fullProductDetails,
+      product: {
+        ...fullProductDetails,
+        id: "pns2",
+      },
       quantity: 1,
     },
   },

--- a/frontend/src/lib/test/fixtures/cart.ts
+++ b/frontend/src/lib/test/fixtures/cart.ts
@@ -1,5 +1,5 @@
 export const fullProductDetails = {
-  id: "fake_id",
+  id: "0000000",
   title: "Product Name 500g",
   image: "https://example.com/product/p1.jpg",
   productPageUrl: "https://example.com/product/p1",
@@ -12,28 +12,175 @@ export const fullProductDetails = {
   promo: null,
 } as Product;
 
-export const preexistingCart = {
+// ----- CART STATES -----
+
+export const emptyCart = {
+  nw: {},
+  pns: {},
+  wls: {},
+};
+
+export const cartWithSingleItem = {
   nw: {
-    nw1: {
+    1110000: {
       product: {
         ...fullProductDetails,
-        id: "nw1",
+        id: "1110000",
+      },
+      quantity: 1,
+    },
+  },
+  pns: {},
+  wls: {},
+};
+
+export const fullCart = {
+  nw: {
+    1110111: {
+      product: {
+        ...fullProductDetails,
+        id: "1110111",
+      },
+      quantity: 50,
+    },
+    1110222: {
+      product: {
+        ...fullProductDetails,
+        id: "1110222",
+      },
+      quantity: 16,
+    },
+  },
+  pns: {
+    2220111: {
+      product: {
+        ...fullProductDetails,
+        id: "2220111",
+      },
+      quantity: 1,
+    },
+    2220222: {
+      product: {
+        ...fullProductDetails,
+        id: "2220222",
+      },
+      quantity: 13,
+    },
+    2220333: {
+      product: {
+        ...fullProductDetails,
+        id: "2220333",
+      },
+      quantity: 74,
+    },
+  },
+  wls: {
+    333011: {
+      product: {
+        ...fullProductDetails,
+        id: "333011",
+      },
+      quantity: 34,
+    },
+    3330222: {
+      product: {
+        ...fullProductDetails,
+        id: "3330222",
+      },
+      quantity: 12,
+    },
+    33303: {
+      product: {
+        ...fullProductDetails,
+        id: "33303",
+      },
+      quantity: 8,
+    },
+    3330444: {
+      product: {
+        ...fullProductDetails,
+        id: "3330444",
+      },
+      quantity: 5,
+    },
+  },
+};
+
+// ----- PARTIALLY FILLED CART & VARIANTS -----
+
+export const partialCart = {
+  nw: {
+    1110001: {
+      product: {
+        ...fullProductDetails,
+        id: "1110001",
       },
       quantity: 5,
     },
   },
   pns: {
-    pns1: {
+    2220001: {
       product: {
         ...fullProductDetails,
-        id: "pns1",
+        id: "2220001",
       },
       quantity: 12,
     },
-    pns2: {
+    2220002: {
       product: {
         ...fullProductDetails,
-        id: "pns2",
+        id: "2220002",
+      },
+      quantity: 1,
+    },
+  },
+  wls: {},
+};
+
+export const partialCart_itemRemoved = {
+  nw: {
+    1110001: {
+      product: {
+        ...fullProductDetails,
+        id: "1110001",
+      },
+      quantity: 5,
+    },
+  },
+  pns: {
+    2220002: {
+      product: {
+        ...fullProductDetails,
+        id: "2220002",
+      },
+      quantity: 1,
+    },
+  },
+  wls: {},
+};
+
+export const partialCart_quantityUpdated = {
+  nw: {
+    1110001: {
+      product: {
+        ...fullProductDetails,
+        id: "1110001",
+      },
+      quantity: 5,
+    },
+  },
+  pns: {
+    2220001: {
+      product: {
+        ...fullProductDetails,
+        id: "2220001",
+      },
+      quantity: 300,
+    },
+    2220002: {
+      product: {
+        ...fullProductDetails,
+        id: "2220002",
       },
       quantity: 1,
     },


### PR DESCRIPTION
<!-- Description of task purpose -->
Users will be able to alter amounts of cart items. Cart context needs functionality to handle this. So enters `updateCartItemQuantity` 🎆 

Project ticket: #122 

### Acceptance Criteria
- [x] Cart context exports function to modify quantity on use
- [x] Duplicate items added with `addItemToCart` update existing item quantity

### Discoveries
<!-- Anything to note/for others' understanding -->

### Testing
<!-- Notes on how to manual test, evidence of added tests passing with 80% coverage etc -->
Tests have been added covering this function (with exception of line 80, as this is to be covered in next update) as there are no components that currently use this.

`npm run test context`

<img width="1590" height="315" alt="Screenshot 2025-08-18 144035" src="https://github.com/user-attachments/assets/83d77174-71ef-4f27-aa06-39d03523d663" />

`npm run test:coverage`

<img width="1483" height="69" alt="Screenshot 2025-08-18 144113" src="https://github.com/user-attachments/assets/7eacc4f5-bd45-4c93-9dcf-9e21af62db7f" />


### Checklist
- [x] tests passing
- [x] applied relevant labels to PR ***(`chore`/`feat`/`fix` etc)***
- [x] added screenshots/recordings ***(if applicable)***

### Screenshots/Recordings ***(optional)***
