### PR TITLE
chore: #159 - card details add to cart button functionality

### DIFF
--- a/frontend/src/components/Card/Card.test.tsx
+++ b/frontend/src/components/Card/Card.test.tsx
@@ -2,6 +2,7 @@ import { screen } from "@testing-library/react";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 
+import { nwProduct } from "@/lib/test/fixtures/products";
 import { renderWithRouter } from "@/lib/test/renderWithRouter";
 
 import { Card } from "./Card";
@@ -13,46 +14,31 @@ vi.mock("../CardDetails", () => ({
 describe("Given a user is on the home page", () => {
   describe("When the Card component is rendered", () => {
     it("Then the user see's the correct image", () => {
-      renderWithRouter(
-        <Card
-          imgSrc="https://a.fsimg.co.nz/product/retail/fan/image/400x400/5023660.png?w=384"
-          productTitle="Pams Butter"
-          price="8.45"
-          store="New World"
-        />,
-      );
+      renderWithRouter(<Card product={nwProduct} />);
 
-      const image = screen.getByAltText(/pams butter/i);
+      const image = screen.getByAltText(
+        /Chia Sisters Gut Lemon & Golden Kiwifruit Sparkling Drink 250ml/i,
+      );
 
       expect(image).toHaveAttribute(
         "src",
-        "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5023660.png?w=384",
+        "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5331318.png?w=384",
       );
-      expect(screen.getByAltText(/pams butter/i)).toBeInTheDocument();
+      expect(
+        screen.getByAltText(
+          /Chia Sisters Gut Lemon & Golden Kiwifruit Sparkling Drink 250ml/i,
+        ),
+      ).toBeInTheDocument();
     });
 
     it("Then it renders the carddetails component", () => {
-      renderWithRouter(
-        <Card
-          imgSrc="https://a.fsimg.co.nz/product/retail/fan/image/400x400/5023660.png?w=384"
-          productTitle="Pams Butter"
-          price="8.45"
-          store="New World"
-        />,
-      );
+      renderWithRouter(<Card product={nwProduct} />);
 
       expect(screen.getByTestId("card-details")).toBeInTheDocument();
     });
 
     it("Then it has no accessibility violations", async () => {
-      const { container } = renderWithRouter(
-        <Card
-          imgSrc="https://a.fsimg.co.nz/product/retail/fan/image/400x400/5023660.png?w=384"
-          productTitle="Pams Butter"
-          price="8.45"
-          store="New World"
-        />,
-      );
+      const { container } = renderWithRouter(<Card product={nwProduct} />);
       const results = await axe(container);
       expect(results).toHaveNoViolations();
     });

--- a/frontend/src/components/Card/Card.tsx
+++ b/frontend/src/components/Card/Card.tsx
@@ -5,14 +5,7 @@ import { cn } from "@/lib/retroui.utils";
 
 import { CardDetails } from "../CardDetails";
 
-export type ProductProps = {
-  imgSrc: string;
-  productTitle: string;
-  price: string;
-  store: string;
-};
-
-export function Card({ imgSrc, productTitle, price, store }: ProductProps) {
+export function Card({ product }: { product: Product }) {
   const { pathname } = useLocation();
   const isHome = pathname === "/";
 
@@ -25,12 +18,12 @@ export function Card({ imgSrc, productTitle, price, store }: ProductProps) {
     >
       <RUICard.Content className="py-0 flex justify-center">
         <img
-          src={imgSrc}
+          src={product.image}
           className={cn(isHome ? "w-50 h-50 " : "w-30 h-30")}
-          alt={productTitle}
+          alt={product.title}
         />
       </RUICard.Content>
-      <CardDetails productTitle={productTitle} price={price} store={store} />
+      <CardDetails product={product} />
     </RUICard>
   );
 }

--- a/frontend/src/components/CardDetails/CardDetails.test.tsx
+++ b/frontend/src/components/CardDetails/CardDetails.test.tsx
@@ -9,7 +9,7 @@ import { renderWithRouter } from "@/lib/test/renderWithRouter";
 
 import { CardDetails } from "./CardDetails";
 
-describe("Given the user is looking at an individual products's details", () => {
+describe("Given the user is looking at an individual product's details", () => {
   describe("When the product is displayed on the home page", () => {
     it("Then the store, product name and price is displayed", () => {
       renderWithRouter(<CardDetails product={nwProduct} />);
@@ -42,28 +42,13 @@ describe("Given the user is looking at an individual products's details", () => 
   });
 
   describe("When the button is rendered", () => {
-    it("Then the text add to cart is displayed", async () => {
+    it("Then the correct text is displayed", async () => {
       renderWithRouter(<CardDetails product={nwProduct} />);
 
       const button = screen.getByRole("button", { name: /add to cart/i });
       expect(button).toBeInTheDocument();
     });
-  });
 
-  describe("When the product details are displayed", () => {
-    it("Then it has no accessibility violations", async () => {
-      const { container } = renderWithRouter(
-        <CardDetails product={nwProduct} />,
-      );
-
-      const results = await axe(container);
-      expect(results).toHaveNoViolations();
-    });
-  });
-
-  // --- INTERACTIONS --- //
-
-  describe("when the add to cart button is displayed", () => {
     const addCartItemMock = vi.fn();
     const removeCartItemMock = vi.fn();
 
@@ -73,9 +58,8 @@ describe("Given the user is looking at an individual products's details", () => 
     } as unknown as CartContext.CartContextType);
 
     const toastSuccessSpy = vi.spyOn(Sonner.toast, "success");
-    const toastErrorSpy = vi.spyOn(Sonner.toast, "error");
 
-    it("Then it adds item to cart", async () => {
+    it("Then it adds item to cart when clicked", async () => {
       renderWithRouter(<CardDetails product={nwProduct} />);
 
       const button = screen.getByRole("button", { name: /add to cart/i });
@@ -91,8 +75,19 @@ describe("Given the user is looking at an individual products's details", () => 
         expect.objectContaining({ richColors: true }),
       );
     });
+  });
+  describe("When an item has been added and the undo button is displayed in the toast", () => {
+    it("Then it can undo adding the item to cart", async () => {
+      const addCartItemMock = vi.fn();
+      const removeCartItemMock = vi.fn();
 
-    it("Then it can undo adding item to cart", async () => {
+      vi.spyOn(CartContext, "useCart").mockReturnValue({
+        addCartItem: addCartItemMock,
+        removeCartItem: removeCartItemMock,
+      } as unknown as CartContext.CartContextType);
+
+      const toastSuccessSpy = vi.spyOn(Sonner.toast, "success");
+      const toastErrorSpy = vi.spyOn(Sonner.toast, "error");
       renderWithRouter(<CardDetails product={nwProduct} />);
 
       await fireEvent.click(screen.getByText(/add to cart/i));
@@ -111,6 +106,17 @@ describe("Given the user is looking at an individual products's details", () => 
         `${nwProduct.title} removed`,
         expect.objectContaining({ richColors: true }),
       );
+    });
+  });
+
+  describe("When the product details are displayed", () => {
+    it("Then it has no accessibility violations", async () => {
+      const { container } = renderWithRouter(
+        <CardDetails product={nwProduct} />,
+      );
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
     });
   });
 });

--- a/frontend/src/components/CardDetails/CardDetails.test.tsx
+++ b/frontend/src/components/CardDetails/CardDetails.test.tsx
@@ -1,57 +1,116 @@
-import { screen } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
+import * as Sonner from "sonner";
+import { vi } from "vitest";
 import { axe } from "vitest-axe";
 
+import * as CartContext from "@/context/CartContext";
+import { nwProduct } from "@/lib/test/fixtures/products";
 import { renderWithRouter } from "@/lib/test/renderWithRouter";
 
 import { CardDetails } from "./CardDetails";
 
-const mockProps = {
-  productTitle: "Pams Butter",
-  price: "3.50",
-  store: "Woolworths",
-};
-
 describe("Given the user is looking at an individual products's details", () => {
   describe("When the product is displayed on the home page", () => {
     it("Then the store, product name and price is displayed", () => {
-      renderWithRouter(<CardDetails {...mockProps} />);
+      renderWithRouter(<CardDetails product={nwProduct} />);
 
-      expect(screen.getByText(/pams butter/i)).toBeInTheDocument();
-      expect(screen.getByText(/woolworths/i)).toBeInTheDocument();
-      expect(screen.getByText("$3.50")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          /Chia Sisters Gut Lemon & Golden Kiwifruit Sparkling Drink 250ml/i,
+        ),
+      ).toBeInTheDocument();
+      // TODO expect(screen.getByText(/new world/i)).toBeInTheDocument(); When the shop code is fixed
+      expect(screen.getByText("$5.59")).toBeInTheDocument();
     });
   });
 
   describe("When the product is displayed on the browse page", () => {
     it("Then product name and price is displayed", () => {
-      renderWithRouter(<CardDetails {...mockProps} />, {
+      renderWithRouter(<CardDetails product={nwProduct} />, {
         route: "/browse",
         path: "/browse",
       });
 
-      expect(screen.queryByText(/woolworths/i)).not.toBeInTheDocument();
-      expect(screen.getByText(/pams butter/i)).toBeInTheDocument();
-      expect(screen.getByText("$3.50")).toBeInTheDocument();
+      expect(screen.queryByText(/new world/i)).not.toBeInTheDocument();
+      expect(
+        screen.getByText(
+          /Chia Sisters Gut Lemon & Golden Kiwifruit Sparkling Drink 250ml/i,
+        ),
+      ).toBeInTheDocument();
+      expect(screen.getByText("$5.59")).toBeInTheDocument();
     });
   });
 
   describe("When the button is rendered", () => {
     it("Then the text add to cart is displayed", async () => {
-      renderWithRouter(<CardDetails {...mockProps} />);
+      renderWithRouter(<CardDetails product={nwProduct} />);
 
-      const button = screen.getByRole("button");
-      expect(button).toHaveTextContent(/add to cart/i);
+      const button = screen.getByRole("button", { name: /add to cart/i });
+      expect(button).toBeInTheDocument();
     });
-
-    it.todo("Then it adds item to cart");
   });
 
   describe("When the product details are displayed", () => {
     it("Then it has no accessibility violations", async () => {
-      const { container } = renderWithRouter(<CardDetails {...mockProps} />);
+      const { container } = renderWithRouter(
+        <CardDetails product={nwProduct} />,
+      );
 
       const results = await axe(container);
       expect(results).toHaveNoViolations();
+    });
+  });
+
+  // --- INTERACTIONS --- //
+
+  describe("when the add to cart button is displayed", () => {
+    const addCartItemMock = vi.fn();
+    const removeCartItemMock = vi.fn();
+
+    vi.spyOn(CartContext, "useCart").mockReturnValue({
+      addCartItem: addCartItemMock,
+      removeCartItem: removeCartItemMock,
+    } as unknown as CartContext.CartContextType);
+
+    const toastSuccessSpy = vi.spyOn(Sonner.toast, "success");
+    const toastErrorSpy = vi.spyOn(Sonner.toast, "error");
+
+    it("Then it adds item to cart", async () => {
+      renderWithRouter(<CardDetails product={nwProduct} />);
+
+      const button = screen.getByRole("button", { name: /add to cart/i });
+      await fireEvent.click(button);
+
+      expect(addCartItemMock).toHaveBeenCalledWith(
+        nwProduct.supermarket,
+        nwProduct,
+      );
+
+      expect(toastSuccessSpy).toHaveBeenCalledWith(
+        `${nwProduct.title} has been added to your cart`,
+        expect.objectContaining({ richColors: true }),
+      );
+    });
+
+    it("Then it can undo adding item to cart", async () => {
+      renderWithRouter(<CardDetails product={nwProduct} />);
+
+      await fireEvent.click(screen.getByText(/add to cart/i));
+
+      const undo = toastSuccessSpy.mock.calls[0][1]?.cancel as unknown as {
+        onClick: () => void;
+      };
+      const undoButtonFunction = undo.onClick;
+      undoButtonFunction();
+
+      expect(removeCartItemMock).toHaveBeenCalledWith(
+        nwProduct.supermarket,
+        nwProduct.id,
+      );
+      expect(toastErrorSpy).toHaveBeenCalledWith(
+        `${nwProduct.title} removed`,
+        expect.objectContaining({ richColors: true }),
+      );
     });
   });
 });

--- a/frontend/src/components/CardDetails/CardDetails.tsx
+++ b/frontend/src/components/CardDetails/CardDetails.tsx
@@ -35,7 +35,7 @@ export function CardDetails({ product }: { product: Product }) {
         </RUICard.Content>
         <RUICard.Content className="flex justify-around  items-center">
           <p className="text-lg font-semibold">${price.value}</p>
-          <Button onClick={() => addToCart()}>Add to cart</Button>
+          <Button onClick={addToCart}>Add to cart</Button>
         </RUICard.Content>
       </div>
     );
@@ -49,7 +49,7 @@ export function CardDetails({ product }: { product: Product }) {
         </RUICard.Header>
         <RUICard.Content className="flex justify-around items-center">
           <p className="">${price.value}</p>
-          <Button onClick={() => addToCart()}>Add to cart</Button>
+          <Button onClick={addToCart}>Add to cart</Button>
         </RUICard.Content>
       </div>
     );

--- a/frontend/src/components/CardDetails/CardDetails.tsx
+++ b/frontend/src/components/CardDetails/CardDetails.tsx
@@ -2,24 +2,23 @@ import { useLocation } from "react-router-dom";
 import { toast } from "sonner";
 
 import { Button, RUICard } from "@/components/retroui";
+import { useCart } from "@/context/CartContext";
 
-import type { ProductProps } from "../Card/Card";
-
-// TODO /browse comp needs styling once in the browse grid
-
-type CardDetailsProps = Omit<ProductProps, "imgSrc">;
-
-export function CardDetails({ productTitle, price, store }: CardDetailsProps) {
+export function CardDetails({ product }: { product: Product }) {
+  const { title, price, supermarket } = product;
   const { pathname } = useLocation();
   const isHome = pathname === "/";
+  const { addCartItem, removeCartItem } = useCart();
 
-  const addToCart = (item: string) => {
-    toast.success(`${item} has been added to your cart`, {
+  const addToCart = () => {
+    addCartItem(supermarket, product);
+    toast.success(`${title} has been added to your cart`, {
       richColors: true,
       cancel: {
         label: "Undo",
         onClick: () => {
-          alert(`${item} removed`);
+          removeCartItem(supermarket, product.id);
+          toast.error(`${title} removed`, { richColors: true });
         },
       },
     });
@@ -29,14 +28,14 @@ export function CardDetails({ productTitle, price, store }: CardDetailsProps) {
     return (
       <div data-testid="card-details">
         <RUICard.Header className="py-0">
-          <RUICard.Title>{store}</RUICard.Title>
+          <RUICard.Title>{supermarket}</RUICard.Title>
         </RUICard.Header>
         <RUICard.Content className="py-0">
-          <p>{productTitle}</p>
+          <p>{title}</p>
         </RUICard.Content>
         <RUICard.Content className="flex justify-around  items-center">
-          <p className="text-lg font-semibold">${price}</p>
-          <Button onClick={() => addToCart(productTitle)}>Add to cart</Button>
+          <p className="text-lg font-semibold">${price.value}</p>
+          <Button onClick={() => addToCart()}>Add to cart</Button>
         </RUICard.Content>
       </div>
     );
@@ -45,12 +44,12 @@ export function CardDetails({ productTitle, price, store }: CardDetailsProps) {
       <div data-testid="card-details">
         <RUICard.Header className="py-0">
           <RUICard.Title className="text-center text-base">
-            {productTitle}
+            {title}
           </RUICard.Title>
         </RUICard.Header>
         <RUICard.Content className="flex justify-around items-center">
-          <p className="">${price}</p>
-          <Button onClick={() => addToCart(productTitle)}>Add to cart</Button>
+          <p className="">${price.value}</p>
+          <Button onClick={() => addToCart()}>Add to cart</Button>
         </RUICard.Content>
       </div>
     );

--- a/frontend/src/components/ProductColumn/ProductColumn.tsx
+++ b/frontend/src/components/ProductColumn/ProductColumn.tsx
@@ -20,15 +20,7 @@ export function ProductColumn({ data, store }: ProductColumnProps) {
         className=" grid grid-cols-2 gap-2 px-2 justify-items-center "
       >
         {data && data.length !== 0 ? (
-          data.map((product) => (
-            <Card
-              key={product.id}
-              imgSrc={product.image}
-              productTitle={product.title}
-              price={product.price.value}
-              store={store}
-            />
-          ))
+          data.map((product) => <Card product={product} key={product.id} />)
         ) : (
           <Text className="text-center" as={"h4"}>
             No products at {store}...

--- a/frontend/src/compositions/Featured/Featured.tsx
+++ b/frontend/src/compositions/Featured/Featured.tsx
@@ -1,5 +1,10 @@
 import { Card } from "@/components/Card";
 import { Text } from "@/components/retroui";
+import {
+  nwProduct,
+  pnsProduct,
+  wlsProduct,
+} from "@/lib/test/fixtures/products";
 
 export function Featured() {
   return (
@@ -11,24 +16,9 @@ export function Featured() {
         Featured items - Butter
       </Text>
       <div className="grid grid-cols-3 text-center mt-4 w-auto justify-items-center">
-        <Card
-          imgSrc="https://a.fsimg.co.nz/product/retail/fan/image/400x400/5023660.png?w=384"
-          productTitle="Pams Butter"
-          price="8.45"
-          store="New World"
-        />
-        <Card
-          imgSrc="https://a.fsimg.co.nz/product/retail/fan/image/400x400/5002650.png?w=384"
-          productTitle="Anchor Butter"
-          price="7.45"
-          store="PAK'nSAVE"
-        />
-        <Card
-          imgSrc="https://a.fsimg.co.nz/product/retail/fan/image/400x400/5004821.png?w=384"
-          productTitle="Rolling Meadow Butter"
-          price="8.9"
-          store="Woolworths"
-        />
+        <Card product={nwProduct} />
+        <Card product={pnsProduct} />
+        <Card product={wlsProduct} />
       </div>
     </section>
   );

--- a/frontend/src/context/CartContext.tsx
+++ b/frontend/src/context/CartContext.tsx
@@ -11,7 +11,7 @@ import { calculateTotals } from "./utils/calculateTotals";
 import { getStartingState } from "./utils/cartData";
 import { setLocalData } from "./utils/localStorage";
 
-type CartContextType = {
+export type CartContextType = {
   nwCart: Cart;
   pnsCart: Cart;
   wlsCart: Cart;
@@ -26,7 +26,9 @@ type CartContextType = {
   ) => void;
 };
 
-const CartContext = createContext<CartContextType | undefined>(undefined);
+export const CartContext = createContext<CartContextType | undefined>(
+  undefined,
+);
 
 export const CartProvider = ({ children }: { children: ReactNode }) => {
   const [nwCart, setNwCart] = useState<Cart>(getStartingState("nw"));


### PR DESCRIPTION
<!-- Description of task purpose -->
Currently, the "Add to Cart" button on the product card/page is only a UI element and does not trigger any cart updates. We need to wire the button to the existing `addCartItem` function from the `CartContext` so that clicking the button correctly adds the selected product to the cart.

Project ticket: #159 

### Acceptance Criteria
- [x] Clicking Add To Cart successfully updates the correct cart

### Discoveries
<!-- Anything to note/for others' understanding -->
- The context functions require the full product so updates needed to be made to props to `Featured.tsx`, `ProductColumn.tsx` and `Card`,  to pass down that object as a whole, as opposed to only passing rendered values

### Testing
<!-- Notes on how to manual test, evidence of added tests passing with 80% coverage etc -->
- In browser: Inspect > Application > Local Storage > http://127.0.0.1:5173/ > smartShopper.cart

### Checklist
- [x] tests passing
- [x] applied relevant labels to PR ***(`chore`/`feat`/`fix` etc)***
- [ ] added screenshots/recordings ***(if applicable)***


### Screenshots/Recordings ***(optional)***
