### PR TITLE
chore #165: product cart item action buttons

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,9 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.7",
+        "@radix-ui/react-visually-hidden": "^1.2.3",
         "@tailwindcss/vite": "^4.1.11",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1476,11 +1478,153 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
       "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
       "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -1498,6 +1642,54 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1551,6 +1743,114 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -3232,6 +3532,18 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -3986,6 +4298,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -5247,6 +5565,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-proto": {
@@ -7533,6 +7860,53 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
+      "integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-router": {
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.7.0.tgz",
@@ -7571,6 +7945,28 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/redent": {
@@ -8652,8 +9048,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/tw-animate-css": {
       "version": "1.3.5",
@@ -8894,6 +9289,49 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,9 @@
     "test:watch": "vitest --watch"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-visually-hidden": "^1.2.3",
     "@tailwindcss/vite": "^4.1.11",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/frontend/src/components/CartProductActions/CartProductActions.test.tsx
+++ b/frontend/src/components/CartProductActions/CartProductActions.test.tsx
@@ -1,0 +1,211 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import { axe } from "vitest-axe";
+
+import * as CartContext from "@/context/CartContext";
+import { nwProduct } from "@/lib/test/fixtures/products";
+import { renderWithRouter } from "@/lib/test/renderWithRouter";
+
+import { CartProductActions } from "./CartProductActions";
+
+const singleMockProduct = {
+  quantity: 782,
+  product: nwProduct,
+} as CartItem;
+
+describe("Given a user is looking at a product in a supermarket cart", () => {
+  describe("when the user is looking the product actions", () => {
+    it("Then it should have no accessibility violations", async () => {
+      const { container } = renderWithRouter(
+        <CartProductActions cartProductItem={singleMockProduct} />,
+      );
+      const results = await axe(container, {
+        rules: {
+          "color-contrast": { enabled: false },
+        },
+      });
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  describe("When the user views the product actions", () => {
+    it("Then it should display the correct quantity", () => {
+      renderWithRouter(
+        <CartProductActions cartProductItem={singleMockProduct} />,
+      );
+
+      const quantityInput = screen.getByTestId(
+        "cart-product-input",
+      ) as HTMLInputElement;
+      expect(quantityInput.value).toBe("782");
+    });
+  });
+
+  describe("When the user interacts the product action buttons", () => {
+    it("Then using the manual input should update the cart total", async () => {
+      const updateCartItemQuantityMock = vi.fn();
+
+      vi.spyOn(CartContext, "useCart").mockReturnValue({
+        updateCartItemQuantity: updateCartItemQuantityMock,
+      } as unknown as CartContext.CartContextType);
+
+      renderWithRouter(
+        <CartProductActions cartProductItem={singleMockProduct} />,
+      );
+
+      const quantityInput = screen.getByTestId(
+        "cart-product-input",
+      ) as HTMLInputElement;
+
+      fireEvent.change(quantityInput, { target: { value: "8" } });
+
+      expect(updateCartItemQuantityMock).toHaveBeenCalledWith(
+        singleMockProduct.product.supermarket,
+        singleMockProduct.product.id,
+        8,
+      );
+    });
+
+    it("Then using the minus button should decrease item quantity by 1", async () => {
+      const updateCartItemQuantityMock = vi.fn();
+
+      vi.spyOn(CartContext, "useCart").mockReturnValue({
+        updateCartItemQuantity: updateCartItemQuantityMock,
+      } as unknown as CartContext.CartContextType);
+
+      renderWithRouter(
+        <CartProductActions cartProductItem={singleMockProduct} />,
+      );
+
+      const minusButton = screen.getByTestId("cart-product-minus");
+      await fireEvent.click(minusButton);
+
+      expect(updateCartItemQuantityMock).toHaveBeenCalledWith(
+        singleMockProduct.product.supermarket,
+        singleMockProduct.product.id,
+        singleMockProduct.quantity - 1,
+      );
+    });
+
+    it("Then using the plus button should increase item quantity by 1", async () => {
+      const updateCartItemQuantityMock = vi.fn();
+
+      vi.spyOn(CartContext, "useCart").mockReturnValue({
+        updateCartItemQuantity: updateCartItemQuantityMock,
+      } as unknown as CartContext.CartContextType);
+
+      renderWithRouter(
+        <CartProductActions cartProductItem={singleMockProduct} />,
+      );
+
+      const plusButton = screen.getByTestId("cart-product-increase");
+      await fireEvent.click(plusButton);
+
+      expect(updateCartItemQuantityMock).toHaveBeenCalledWith(
+        singleMockProduct.product.supermarket,
+        singleMockProduct.product.id,
+        singleMockProduct.quantity + 1,
+      );
+    });
+
+    it("Then using the trash button should remove the product from the cart", async () => {
+      const removeCartItemMock = vi.fn();
+
+      vi.spyOn(CartContext, "useCart").mockReturnValue({
+        removeCartItem: removeCartItemMock,
+      } as unknown as CartContext.CartContextType);
+
+      renderWithRouter(
+        <CartProductActions cartProductItem={singleMockProduct} />,
+      );
+
+      const trashButton = screen.getByTestId("cart-product-trash");
+      fireEvent.click(trashButton);
+
+      const confirmButton = await screen.findByRole("button", {
+        name: /confirm/i,
+      });
+      expect(confirmButton).toBeInTheDocument();
+
+      await fireEvent.click(confirmButton);
+
+      expect(removeCartItemMock).toHaveBeenCalledWith(
+        singleMockProduct.product.supermarket,
+        singleMockProduct.product.id,
+      );
+    });
+
+    it("Then using the minus button when the quantity is 1 should ask the user for deletion confirmation ", async () => {
+      const updateCartItemQuantityMock = vi.fn();
+
+      vi.spyOn(CartContext, "useCart").mockReturnValue({
+        updateCartItemQuantity: updateCartItemQuantityMock,
+      } as unknown as CartContext.CartContextType);
+
+      renderWithRouter(
+        <CartProductActions
+          cartProductItem={{
+            quantity: 1,
+            product: nwProduct,
+          }}
+        />,
+      );
+
+      const minusButton = screen.getByTestId("cart-product-minus");
+      await fireEvent.click(minusButton);
+
+      const trashConfirmButton = await screen.findByRole("button", {
+        name: /confirm/i,
+      });
+      expect(trashConfirmButton).toBeInTheDocument();
+    });
+  });
+
+  describe("When the user incorrectly inputs invalid data", () => {
+    let updateCartItemQuantityMock: ReturnType<typeof vi.fn>;
+    let quantityInput: HTMLInputElement;
+
+    beforeEach(() => {
+      updateCartItemQuantityMock = vi.fn();
+
+      vi.spyOn(CartContext, "useCart").mockReturnValue({
+        updateCartItemQuantity: updateCartItemQuantityMock,
+      } as unknown as CartContext.CartContextType);
+
+      renderWithRouter(
+        <CartProductActions cartProductItem={singleMockProduct} />,
+      );
+
+      quantityInput = screen.getByTestId(
+        "cart-product-input",
+      ) as HTMLInputElement;
+    });
+
+    it("Then using the manual input with an value of 0 should update the cart total to 1", async () => {
+      fireEvent.change(quantityInput, { target: { value: "0" } });
+      expect(updateCartItemQuantityMock).toHaveBeenCalledWith(
+        singleMockProduct.product.supermarket,
+        singleMockProduct.product.id,
+        1,
+      );
+    });
+
+    it("Then using the manual input with an invalid input should update the cart total to 1", async () => {
+      fireEvent.change(quantityInput, { target: { value: "-5" } });
+      expect(updateCartItemQuantityMock).toHaveBeenCalledWith(
+        singleMockProduct.product.supermarket,
+        singleMockProduct.product.id,
+        1,
+      );
+    });
+
+    it("Then using the manual input with an invalid input should update the cart total to 1", async () => {
+      fireEvent.change(quantityInput, { target: { value: NaN } });
+      expect(updateCartItemQuantityMock).toHaveBeenCalledWith(
+        singleMockProduct.product.supermarket,
+        singleMockProduct.product.id,
+        1,
+      );
+    });
+  });
+});

--- a/frontend/src/components/CartProductActions/CartProductActions.test.tsx
+++ b/frontend/src/components/CartProductActions/CartProductActions.test.tsx
@@ -14,7 +14,17 @@ const singleMockProduct = {
 } as CartItem;
 
 describe("Given a user is looking at a product in a supermarket cart", () => {
-  describe("when the user is looking the product actions", () => {
+  describe("When the user is looking the product actions", () => {
+    it("Then it should display the correct quantity", () => {
+      renderWithRouter(
+        <CartProductActions cartProductItem={singleMockProduct} />,
+      );
+
+      const quantityInput = screen.getByTestId(
+        "cart-product-input",
+      ) as HTMLInputElement;
+      expect(quantityInput.value).toBe("782");
+    });
     it("Then it should have no accessibility violations", async () => {
       const { container } = renderWithRouter(
         <CartProductActions cartProductItem={singleMockProduct} />,
@@ -28,21 +38,8 @@ describe("Given a user is looking at a product in a supermarket cart", () => {
     });
   });
 
-  describe("When the user views the product actions", () => {
-    it("Then it should display the correct quantity", () => {
-      renderWithRouter(
-        <CartProductActions cartProductItem={singleMockProduct} />,
-      );
-
-      const quantityInput = screen.getByTestId(
-        "cart-product-input",
-      ) as HTMLInputElement;
-      expect(quantityInput.value).toBe("782");
-    });
-  });
-
-  describe("When the user interacts the product action buttons", () => {
-    it("Then using the manual input should update the cart total", async () => {
+  describe("When the user interacts with the product action buttons", () => {
+    it("Then using the typing input updates the cart total", async () => {
       const updateCartItemQuantityMock = vi.fn();
 
       vi.spyOn(CartContext, "useCart").mockReturnValue({
@@ -66,7 +63,7 @@ describe("Given a user is looking at a product in a supermarket cart", () => {
       );
     });
 
-    it("Then using the minus button should decrease item quantity by 1", async () => {
+    it("Then clicking the minus button decreases item quantity by 1", async () => {
       const updateCartItemQuantityMock = vi.fn();
 
       vi.spyOn(CartContext, "useCart").mockReturnValue({
@@ -87,7 +84,7 @@ describe("Given a user is looking at a product in a supermarket cart", () => {
       );
     });
 
-    it("Then using the plus button should increase item quantity by 1", async () => {
+    it("Then clicking the plus button increases item quantity by 1", async () => {
       const updateCartItemQuantityMock = vi.fn();
 
       vi.spyOn(CartContext, "useCart").mockReturnValue({
@@ -108,7 +105,7 @@ describe("Given a user is looking at a product in a supermarket cart", () => {
       );
     });
 
-    it("Then using the trash button should remove the product from the cart", async () => {
+    it("Then clicking the trash button removes the product from the cart", async () => {
       const removeCartItemMock = vi.fn();
 
       vi.spyOn(CartContext, "useCart").mockReturnValue({
@@ -135,7 +132,7 @@ describe("Given a user is looking at a product in a supermarket cart", () => {
       );
     });
 
-    it("Then using the minus button when the quantity is 1 should ask the user for deletion confirmation ", async () => {
+    it("Then clicking the minus button when the quantity is 1 asks the user for deletion confirmation ", async () => {
       const updateCartItemQuantityMock = vi.fn();
 
       vi.spyOn(CartContext, "useCart").mockReturnValue({
@@ -161,7 +158,7 @@ describe("Given a user is looking at a product in a supermarket cart", () => {
     });
   });
 
-  describe("When the user incorrectly inputs invalid data", () => {
+  describe("When the user inputs invalid data", () => {
     let updateCartItemQuantityMock: ReturnType<typeof vi.fn>;
     let quantityInput: HTMLInputElement;
 
@@ -181,31 +178,19 @@ describe("Given a user is looking at a product in a supermarket cart", () => {
       ) as HTMLInputElement;
     });
 
-    it("Then using the manual input with an value of 0 should update the cart total to 1", async () => {
+    it("Then using the typing input with a value of 0 updates the cart total to 1", async () => {
       fireEvent.change(quantityInput, { target: { value: "0" } });
-      expect(updateCartItemQuantityMock).toHaveBeenCalledWith(
-        singleMockProduct.product.supermarket,
-        singleMockProduct.product.id,
-        1,
-      );
+      expect(updateCartItemQuantityMock).not.toHaveBeenCalled();
     });
 
-    it("Then using the manual input with an invalid input should update the cart total to 1", async () => {
+    it("Then using the typing input with an invalid input changes the cart total to 1", async () => {
       fireEvent.change(quantityInput, { target: { value: "-5" } });
-      expect(updateCartItemQuantityMock).toHaveBeenCalledWith(
-        singleMockProduct.product.supermarket,
-        singleMockProduct.product.id,
-        1,
-      );
+      expect(updateCartItemQuantityMock).not.toHaveBeenCalled();
     });
 
-    it("Then using the manual input with an invalid input should update the cart total to 1", async () => {
+    it("Then using the typing input with a NaN input keeps quantity as previous value", async () => {
       fireEvent.change(quantityInput, { target: { value: NaN } });
-      expect(updateCartItemQuantityMock).toHaveBeenCalledWith(
-        singleMockProduct.product.supermarket,
-        singleMockProduct.product.id,
-        1,
-      );
+      expect(updateCartItemQuantityMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/components/CartProductActions/CartProductActions.tsx
+++ b/frontend/src/components/CartProductActions/CartProductActions.tsx
@@ -1,10 +1,10 @@
 import { Minus, Plus, Trash } from "lucide-react";
 import { useState } from "react";
 
+import { DeleteConfirmation } from "@/components/DeleteConfirmation";
 import { Button, Input, Label } from "@/components/retroui";
 import { useCart } from "@/context/CartContext";
 
-import { DeleteConfirmation } from "../DeleteConfirmation";
 import { handleCartAction } from "./utils/cartActions";
 
 export function CartProductActions({

--- a/frontend/src/components/CartProductActions/CartProductActions.tsx
+++ b/frontend/src/components/CartProductActions/CartProductActions.tsx
@@ -1,9 +1,10 @@
 import { Minus, Plus, Trash } from "lucide-react";
 import { useState } from "react";
 
-import { Button, Dialog, Input, Label, Text } from "@/components/retroui";
+import { Button, Input, Label } from "@/components/retroui";
 import { useCart } from "@/context/CartContext";
 
+import { DeleteConfirmation } from "../DeleteConfirmation";
 import { handleCartAction } from "./utils/cartActions";
 
 export function CartProductActions({
@@ -92,38 +93,17 @@ export function CartProductActions({
             <Trash className="w-4 h-4" />
           </Button>
 
-          <Dialog open={openConfirmDelete} onOpenChange={setOpenConfirmDelete}>
-            <Dialog.Content aria-describedby={undefined}>
-              <Dialog.Header position="fixed" asChild>
-                <Text as="h5">Confirm delete</Text>
-              </Dialog.Header>
-              <section className="flex flex-col gap-4 p-4">
-                <section className="text-xl">
-                  <Text>
-                    Are you sure you want to remove {title} from your cart?
-                  </Text>
-                </section>
-                <section className="flex flex-row gap-4 justify-end">
-                  <Dialog.Trigger asChild>
-                    <Button
-                      className="bg-destructive text-white hover:bg-destructive/90"
-                      onClick={() =>
-                        handleCartAction({
-                          action: "delete",
-                          utilArgs,
-                        })
-                      }
-                    >
-                      Confirm
-                    </Button>
-                  </Dialog.Trigger>
-                  <Dialog.Trigger asChild>
-                    <Button variant="outline">Cancel</Button>
-                  </Dialog.Trigger>
-                </section>
-              </section>
-            </Dialog.Content>
-          </Dialog>
+          <DeleteConfirmation
+            open={openConfirmDelete}
+            onOpenChange={setOpenConfirmDelete}
+            title={title}
+            onConfirm={() =>
+              handleCartAction({
+                action: "delete",
+                utilArgs,
+              })
+            }
+          />
         </div>
       </div>
     </div>

--- a/frontend/src/components/CartProductActions/CartProductActions.tsx
+++ b/frontend/src/components/CartProductActions/CartProductActions.tsx
@@ -1,0 +1,131 @@
+import { Minus, Plus, Trash } from "lucide-react";
+import { useState } from "react";
+
+import { Button, Dialog, Input, Label, Text } from "@/components/retroui";
+import { useCart } from "@/context/CartContext";
+
+import { handleCartAction } from "./utils/cartActions";
+
+export function CartProductActions({
+  cartProductItem,
+}: {
+  cartProductItem: CartItem;
+}) {
+  const { removeCartItem, updateCartItemQuantity } = useCart();
+  const [openConfirmDelete, setOpenConfirmDelete] = useState(false);
+
+  const { quantity, product } = cartProductItem;
+  const { id, supermarket, title } = product;
+  const utilArgs = {
+    supermarket,
+    id,
+    quantity,
+    updateCartItemQuantity,
+    removeCartItem,
+  };
+
+  return (
+    <div className="flex-1 flex justify-around min-h-full items-center gap-6">
+      <form
+        className="flex flex-row gap-4 items-center justify-around"
+        onSubmit={(e) => e.preventDefault()}
+      >
+        <Label htmlFor="quantity" className="font-sans text-base">
+          Quantity:
+        </Label>
+        <div className="w-[50%]">
+          <Input
+            data-testid="cart-product-input"
+            type="number"
+            value={quantity}
+            id="quantity"
+            name="quantity"
+            onChange={(e) => {
+              handleCartAction({
+                action: "input",
+                utilArgs,
+                value: Number(e.target.value),
+              });
+            }}
+          />
+        </div>
+      </form>
+
+      <div className="flex flex-col gap-5">
+        <div className="flex gap-5 justify-between items-center">
+          <Button
+            data-testid="cart-product-minus"
+            onClick={() =>
+              handleCartAction({
+                action: "decrease",
+                utilArgs,
+                onRequireConfirm: () => setOpenConfirmDelete(true),
+              })
+            }
+            size="icon"
+            aria-label="Decrease quantity"
+          >
+            <Minus className="w-4 h-4" />
+          </Button>
+
+          <Button
+            data-testid="cart-product-increase"
+            onClick={() =>
+              handleCartAction({
+                action: "increase",
+                utilArgs,
+              })
+            }
+            size="icon"
+            aria-label="Increase quantity"
+          >
+            <Plus className="w-4 h-4" />
+          </Button>
+
+          <Button
+            data-testid="cart-product-trash"
+            size="icon"
+            className="bg-destructive text-white hover:bg-destructive/90"
+            aria-label="Remove from cart"
+            onClick={() => setOpenConfirmDelete(true)}
+          >
+            <Trash className="w-4 h-4" />
+          </Button>
+
+          <Dialog open={openConfirmDelete} onOpenChange={setOpenConfirmDelete}>
+            <Dialog.Content aria-describedby={undefined}>
+              <Dialog.Header position="fixed" asChild>
+                <Text as="h5">Confirm delete</Text>
+              </Dialog.Header>
+              <section className="flex flex-col gap-4 p-4">
+                <section className="text-xl">
+                  <Text>
+                    Are you sure you want to remove {title} from your cart?
+                  </Text>
+                </section>
+                <section className="flex flex-row gap-4 justify-end">
+                  <Dialog.Trigger asChild>
+                    <Button
+                      className="bg-destructive text-white hover:bg-destructive/90"
+                      onClick={() =>
+                        handleCartAction({
+                          action: "delete",
+                          utilArgs,
+                        })
+                      }
+                    >
+                      Confirm
+                    </Button>
+                  </Dialog.Trigger>
+                  <Dialog.Trigger asChild>
+                    <Button variant="outline">Cancel</Button>
+                  </Dialog.Trigger>
+                </section>
+              </section>
+            </Dialog.Content>
+          </Dialog>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/CartProductActions/index.ts
+++ b/frontend/src/components/CartProductActions/index.ts
@@ -1,0 +1,1 @@
+export { CartProductActions } from "./CartProductActions";

--- a/frontend/src/components/CartProductActions/utils/cartActions.ts
+++ b/frontend/src/components/CartProductActions/utils/cartActions.ts
@@ -10,12 +10,12 @@ type UtilArgs = {
   removeCartItem: CartContextType["removeCartItem"];
 };
 
-interface CartActionArgs {
+type CartActionArgs = {
   action: CartActionType;
   utilArgs: UtilArgs;
   value?: number;
   onRequireConfirm?: () => void;
-}
+};
 
 /**
  * handleCartAction - Handles cart updates based on the specified action
@@ -54,6 +54,9 @@ export function handleCartAction({
       break;
     }
     case "input": {
+      if (value === undefined || isNaN(value) || value <= 0) {
+        return;
+      }
       const newQuantity = Math.max(1, Number(value) || 1);
       updateCartItemQuantity(supermarket, id, newQuantity);
       break;

--- a/frontend/src/components/CartProductActions/utils/cartActions.ts
+++ b/frontend/src/components/CartProductActions/utils/cartActions.ts
@@ -1,0 +1,66 @@
+import { type CartContextType } from "@/context/CartContext";
+
+type CartActionType = "increase" | "decrease" | "delete" | "input";
+
+type UtilArgs = {
+  supermarket: ShopCode;
+  id: string;
+  quantity: number;
+  updateCartItemQuantity: CartContextType["updateCartItemQuantity"];
+  removeCartItem: CartContextType["removeCartItem"];
+};
+
+interface CartActionArgs {
+  action: CartActionType;
+  utilArgs: UtilArgs;
+  value?: number;
+  onRequireConfirm?: () => void;
+}
+
+/**
+ * handleCartAction - Handles cart updates based on the specified action
+ *
+ * The function supports four different actions
+ *  - increase: Increases quantity by 1
+ *  - decrease: Decreases quantity by 1
+ *  - delete: Removes the item from the cart
+ *  - input: Updates the quantity based on user input
+ *
+ * @param {CartActionArgs} args - The arguments for the cart action
+ * @param {CartActionType} args.action - The type of action to perform
+ * @param {UtilArgs} args.utilArgs - Utility functions and cart item info
+ * @param {number} [args.value=1] - The quantity for the "input" action
+ * @param {Function} [args.onRequireConfirm] - Optional callback if delete confirmation is required
+ */
+export function handleCartAction({
+  action,
+  utilArgs,
+  value,
+  onRequireConfirm,
+}: CartActionArgs) {
+  const { supermarket, id, quantity, updateCartItemQuantity, removeCartItem } =
+    utilArgs;
+  switch (action) {
+    case "increase": {
+      updateCartItemQuantity(supermarket, id, quantity + 1);
+      break;
+    }
+    case "decrease": {
+      if (quantity > 1) {
+        updateCartItemQuantity(supermarket, id, quantity - 1);
+      } else {
+        onRequireConfirm?.();
+      }
+      break;
+    }
+    case "input": {
+      const newQuantity = Math.max(1, Number(value) || 1);
+      updateCartItemQuantity(supermarket, id, newQuantity);
+      break;
+    }
+    case "delete": {
+      removeCartItem(supermarket, id);
+      break;
+    }
+  }
+}

--- a/frontend/src/components/DeleteConfirmation/DeleteConfirmation.tsx
+++ b/frontend/src/components/DeleteConfirmation/DeleteConfirmation.tsx
@@ -1,0 +1,43 @@
+import { Button, Dialog, Text } from "@/components/retroui";
+
+type ConfirmDeleteDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  onConfirm: () => void;
+};
+
+export function DeleteConfirmation({
+  open,
+  onOpenChange,
+  title,
+  onConfirm,
+}: ConfirmDeleteDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <Dialog.Content aria-describedby={undefined}>
+        <Dialog.Header position="fixed" asChild>
+          <Text as="h5">Confirm delete</Text>
+        </Dialog.Header>
+        <section className="flex flex-col gap-4 p-4">
+          <section className="text-xl">
+            <Text>Are you sure you want to remove {title} from your cart?</Text>
+          </section>
+          <section className="flex flex-row gap-4 justify-end">
+            <Dialog.Trigger asChild>
+              <Button
+                className="bg-destructive text-white hover:bg-destructive/90"
+                onClick={onConfirm}
+              >
+                Confirm
+              </Button>
+            </Dialog.Trigger>
+            <Dialog.Trigger asChild>
+              <Button variant="outline">Cancel</Button>
+            </Dialog.Trigger>
+          </section>
+        </section>
+      </Dialog.Content>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/DeleteConfirmation/index.ts
+++ b/frontend/src/components/DeleteConfirmation/index.ts
@@ -1,0 +1,1 @@
+export { DeleteConfirmation } from "./DeleteConfirmation";

--- a/frontend/src/components/retroui/Dialog.tsx
+++ b/frontend/src/components/retroui/Dialog.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import * as ReactDialog from "@radix-ui/react-dialog";
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react";
+import React, { type HTMLAttributes, type ReactNode } from "react";
+
+import { cn } from "@/lib/retroui.utils";
+
+const Dialog = ReactDialog.Root;
+const DialogTrigger = ReactDialog.Trigger;
+
+const overlayVariants = cva(
+  ` fixed bg-black/80 font-head
+    data-[state=open]:fade-in-0
+    data-[state=open]:animate-in 
+    data-[state=closed]:animate-out 
+    data-[state=closed]:fade-out-0 
+  `,
+  {
+    variants: {
+      variant: {
+        default: "inset-0 z-50 bg-black/80",
+        none: "fixed bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+interface IDialogBackgroupProps
+  extends HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof overlayVariants> {}
+
+const DialogBackdrop = React.forwardRef<HTMLDivElement, IDialogBackgroupProps>(
+  (inputProps: IDialogBackgroupProps, forwardedRef) => {
+    const { variant = "default", className, ...props } = inputProps;
+
+    return (
+      <ReactDialog.Overlay
+        className={cn(overlayVariants({ variant }), className)}
+        ref={forwardedRef}
+        {...props}
+      />
+    );
+  },
+);
+DialogBackdrop.displayName = "DialogBackdrop";
+
+const dialogVariants = cva(
+  `fixed z-50 left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 
+  flex flex-col border-2 shadow-md gap-4 overflow-y-auto bg-background text-foreground
+  w-full h-fit max-h-[80vh] max-w-[97%] duration-300
+  data-[state=open]:animate-in 
+  data-[state=open]:slide-in-from-left-1/2 
+  data-[state=open]:slide-in-from-top-[48%]
+  data-[state=open]:fade-in-0 
+  data-[state=open]:zoom-in-95 
+  data-[state=closed]:animate-out 
+  data-[state=closed]:fade-out-0 
+  data-[state=closed]:slide-out-to-top-[48%] 
+  data-[state=closed]:slide-out-to-left-1/2 
+  data-[state=closed]:zoom-out-95`,
+  {
+    variants: {
+      size: {
+        auto: "max-w-fit",
+        sm: "lg:max-w-[30%]",
+        md: "lg:max-w-[40%]",
+        lg: "lg:max-w-[50%]",
+        xl: "lg:max-w-[60%]",
+        "2xl": "lg:max-w-[70%]",
+        "3xl": "lg:max-w-[80%]",
+        "4xl": "lg:max-w-[90%]",
+        screen: "max-w-[100%]",
+      },
+    },
+    defaultVariants: {
+      size: "auto",
+    },
+  },
+);
+
+interface IDialogContentProps
+  extends HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof dialogVariants> {
+  overlay?: IDialogBackgroupProps;
+}
+
+const DialogContent = React.forwardRef<HTMLDivElement, IDialogContentProps>(
+  (inputProps: IDialogContentProps, forwardedRef) => {
+    const {
+      children,
+      size = "auto",
+      className,
+      overlay,
+      ...props
+    } = inputProps;
+
+    return (
+      <ReactDialog.Portal>
+        <DialogBackdrop {...overlay} />
+        <ReactDialog.Content
+          className={cn(dialogVariants({ size }), className)}
+          ref={forwardedRef}
+          {...props}
+        >
+          <VisuallyHidden>
+            <ReactDialog.Title />
+          </VisuallyHidden>
+          <div className="flex flex-col relative">{children}</div>
+        </ReactDialog.Content>
+      </ReactDialog.Portal>
+    );
+  },
+);
+DialogContent.displayName = "DialogContent";
+
+// interface IDialogDescriptionProps extends HTMLAttributes<HTMLDivElement> {}
+const DialogDescription = ({
+  children,
+  className,
+  ...props
+  // Changed from IDialogDescriptionProps to HTMLAttributes<HTMLDivElement> as it didnt actually extend anything
+  // But leaving here in case something tweaks in the future
+}: HTMLAttributes<HTMLDivElement>) => {
+  return (
+    <ReactDialog.Description className={cn(className)} {...props}>
+      {children}
+    </ReactDialog.Description>
+  );
+};
+
+const dialogFooterVariants = cva(
+  "flex items-center justify-end border-t-2 min-h-12 gap-4 px-4 py-2",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+      },
+      position: {
+        fixed: "sticky bottom-0",
+        static: "static",
+      },
+    },
+    defaultVariants: {
+      position: "fixed",
+    },
+  },
+);
+
+export interface IDialogFooterProps
+  extends HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof dialogFooterVariants> {}
+
+const DialogFooter = ({
+  children,
+  className,
+  position,
+  variant,
+  ...props
+}: IDialogFooterProps) => {
+  return (
+    <div
+      className={cn(dialogFooterVariants({ position, variant }), className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+};
+
+const dialogHeaderVariants = cva(
+  "flex items-center justify-between border-b-2 px-4 min-h-12",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-black",
+      },
+      position: {
+        fixed: "sticky top-0",
+        static: "static",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      position: "static",
+    },
+  },
+);
+
+const DialogHeaderDefaultLayout = ({ children }: { children: ReactNode }) => {
+  return (
+    <>
+      {children}
+      <DialogTrigger title="Close pop-up" className="cursor-pointer" asChild>
+        <X />
+      </DialogTrigger>
+    </>
+  );
+};
+
+interface IDialogHeaderProps
+  extends HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof dialogHeaderVariants>,
+    ReactDialog.DialogTitleProps {}
+
+const DialogHeader = ({
+  children,
+  className,
+  position,
+  variant,
+  asChild,
+  ...props
+}: IDialogHeaderProps) => {
+  return (
+    <div
+      className={cn(dialogHeaderVariants({ position, variant }), className)}
+      {...props}
+    >
+      {asChild ? (
+        children
+      ) : (
+        <DialogHeaderDefaultLayout>{children}</DialogHeaderDefaultLayout>
+      )}
+    </div>
+  );
+};
+
+const DialogComponent = Object.assign(Dialog, {
+  Trigger: DialogTrigger,
+  Header: DialogHeader,
+  Content: DialogContent,
+  Description: DialogDescription,
+  Footer: DialogFooter,
+});
+
+export { DialogComponent as Dialog };

--- a/frontend/src/components/retroui/index.tsx
+++ b/frontend/src/components/retroui/index.tsx
@@ -1,5 +1,6 @@
 export * from "./Button";
 export * from "./Card";
+export * from "./Dialog";
 export * from "./Input";
 export * from "./Label";
 export * from "./Sonner";

--- a/frontend/src/compositions/CartProduct/CartProduct.tsx
+++ b/frontend/src/compositions/CartProduct/CartProduct.tsx
@@ -1,13 +1,12 @@
-import { Minus, Plus, Trash } from "lucide-react";
-
-import { Button, Input, Label, Text } from "@/components/retroui";
+import { CartProductActions } from "@/components/CartProductActions";
+import { Text } from "@/components/retroui";
 
 export function CartProduct({
   cartProductItem,
 }: {
   cartProductItem: CartItem;
 }) {
-  const { product, quantity } = cartProductItem;
+  const { product } = cartProductItem;
   return (
     <div className="flex border items-center justify-center">
       <div className=" p-6">
@@ -25,34 +24,7 @@ export function CartProduct({
           ${product?.price?.value ?? "0.00"}
         </Text>
       </div>
-      <div className="flex-1 flex justify-around min-h-full items-center gap-6">
-        <div className="flex flex-row gap-4 items-center justify-around">
-          <Label htmlFor="quantity" className="font-sans text-base">
-            Quantity:
-          </Label>
-          <div className="w-[50%]">
-            <Input type="number" value={quantity ?? 0} id="quantity" />
-          </div>
-        </div>
-
-        <div className="flex flex-col gap-5">
-          <div className="flex gap-5 justify-between items-center">
-            <Button size="icon" aria-label="Decrease quantity">
-              <Minus className="w-4 h-4" />
-            </Button>
-            <Button size="icon" aria-label="Increase quantity">
-              <Plus className="w-4 h-4" />
-            </Button>
-            <Button
-              size="icon"
-              className="bg-destructive text-white hover:bg-destructive/90"
-              aria-label="Remove from cart"
-            >
-              <Trash className="w-4 h-4" />
-            </Button>
-          </div>
-        </div>
-      </div>
+      <CartProductActions cartProductItem={cartProductItem} />
     </div>
   );
 }


### PR DESCRIPTION
<!-- Description of task purpose -->
Currently the quantity input, decrease and increase buttons and delete button only UI elements and do not trigger any cart actions. We need to wire the button to the `cartContext` functions so that clicking the buttons and input updates the cart

Project ticket: #165 

### Acceptance Criteria
- [x] Action buttons are separated into their own `CartProductActions.tsx` component
- [x] Users can manually input a number to update the cart
- [x] Users can decrease the quantity of a product using a ` - ` button
- [x] Users can increase the quantity of a product using a ` + ` button
- [x] Users can remove an item using the remove/trash button
- [x] Cart quantities and totals are updating it real time

### Discoveries
<!-- Anything to note/for others' understanding -->
- Added a confirmation when the user hits the ` - ` button when item is at 1, and when trying to deleta

### Testing
<!-- Notes on how to manual test, evidence of added tests passing with 80% coverage etc -->
<img width="2007" height="313" alt="Screenshot 2025-09-02 094841" src="https://github.com/user-attachments/assets/8348f616-2b0d-4efe-bd18-5d5e7e3948ce" />
<img width="748" height="73" alt="Screenshot 2025-09-02 095802" src="https://github.com/user-attachments/assets/de6d5722-14f5-4d75-aca6-51a85872ee68" />



### Checklist
- [x] tests passing
- [x] applied relevant labels to PR ***(`chore`/`feat`/`fix` etc)***
- [x] added screenshots/recordings ***(if applicable)***


### Screenshots/Recordings ***(optional)***

https://github.com/user-attachments/assets/0693f7e6-7b7e-41a0-a0b2-8ea1b4bd4fc7


