### PR TITLE
chore: #55 - empty cart button

### DIFF
--- a/frontend/src/components/CartProductActions/CartProductActions.tsx
+++ b/frontend/src/components/CartProductActions/CartProductActions.tsx
@@ -1,11 +1,11 @@
 import { Minus, Plus, Trash } from "lucide-react";
 import { useState } from "react";
 
-import { DeleteConfirmation } from "@/components/DeleteConfirmation";
+import { ConfirmationPopup } from "@/components/ConfirmationPopup";
 import { Button, Input, Label } from "@/components/retroui";
 import { useCart } from "@/context/CartContext";
 
-import { handleCartAction } from "./utils/cartActions";
+import { handleProductAction } from "./utils/cartActions";
 
 export function CartProductActions({
   cartProductItem,
@@ -42,7 +42,7 @@ export function CartProductActions({
             id="quantity"
             name="quantity"
             onChange={(e) => {
-              handleCartAction({
+              handleProductAction({
                 action: "input",
                 utilArgs,
                 value: Number(e.target.value),
@@ -57,7 +57,7 @@ export function CartProductActions({
           <Button
             data-testid="cart-product-minus"
             onClick={() =>
-              handleCartAction({
+              handleProductAction({
                 action: "decrease",
                 utilArgs,
                 onRequireConfirm: () => setOpenConfirmDelete(true),
@@ -72,7 +72,7 @@ export function CartProductActions({
           <Button
             data-testid="cart-product-increase"
             onClick={() =>
-              handleCartAction({
+              handleProductAction({
                 action: "increase",
                 utilArgs,
               })
@@ -93,16 +93,17 @@ export function CartProductActions({
             <Trash className="w-4 h-4" />
           </Button>
 
-          <DeleteConfirmation
+          <ConfirmationPopup
             open={openConfirmDelete}
             onOpenChange={setOpenConfirmDelete}
             title={title}
             onConfirm={() =>
-              handleCartAction({
+              handleProductAction({
                 action: "delete",
                 utilArgs,
               })
             }
+            mode="removeProduct"
           />
         </div>
       </div>

--- a/frontend/src/components/CartProductActions/utils/cartActions.ts
+++ b/frontend/src/components/CartProductActions/utils/cartActions.ts
@@ -1,8 +1,13 @@
 import { type CartContextType } from "@/context/CartContext";
 
-type CartActionType = "increase" | "decrease" | "delete" | "input";
+type CartActionType =
+  | "increase"
+  | "decrease"
+  | "delete"
+  | "input"
+  | "clearCart";
 
-type UtilArgs = {
+type ProductUtilArgs = {
   supermarket: ShopCode;
   id: string;
   quantity: number;
@@ -10,9 +15,13 @@ type UtilArgs = {
   removeCartItem: CartContextType["removeCartItem"];
 };
 
+type ClearCartUtilArgs = {
+  clearCart: CartContextType["clearCart"];
+};
+
 type CartActionArgs = {
   action: CartActionType;
-  utilArgs: UtilArgs;
+  utilArgs: ProductUtilArgs | ClearCartUtilArgs;
   value?: number;
   onRequireConfirm?: () => void;
 };
@@ -25,6 +34,7 @@ type CartActionArgs = {
  *  - decrease: Decreases quantity by 1
  *  - delete: Removes the item from the cart
  *  - input: Updates the quantity based on user input
+ *  - clearCart: Clears the entire cart
  *
  * @param {CartActionArgs} args - The arguments for the cart action
  * @param {CartActionType} args.action - The type of action to perform
@@ -32,14 +42,14 @@ type CartActionArgs = {
  * @param {number} [args.value=1] - The quantity for the "input" action
  * @param {Function} [args.onRequireConfirm] - Optional callback if delete confirmation is required
  */
-export function handleCartAction({
+export function handleProductAction({
   action,
   utilArgs,
   value,
   onRequireConfirm,
 }: CartActionArgs) {
   const { supermarket, id, quantity, updateCartItemQuantity, removeCartItem } =
-    utilArgs;
+    utilArgs as ProductUtilArgs;
   switch (action) {
     case "increase": {
       updateCartItemQuantity(supermarket, id, quantity + 1);
@@ -63,6 +73,17 @@ export function handleCartAction({
     }
     case "delete": {
       removeCartItem(supermarket, id);
+      break;
+    }
+  }
+}
+
+// Moved into a switch, if we include more cart actions
+export function handleCartAction({ action, utilArgs }: CartActionArgs) {
+  const { clearCart } = utilArgs as ClearCartUtilArgs;
+  switch (action) {
+    case "clearCart": {
+      clearCart();
       break;
     }
   }

--- a/frontend/src/components/ConfirmationPopup/ConfirmationPopup.tsx
+++ b/frontend/src/components/ConfirmationPopup/ConfirmationPopup.tsx
@@ -3,16 +3,22 @@ import { Button, Dialog, Text } from "@/components/retroui";
 type ConfirmDeleteDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  title: string;
+  title?: string;
   onConfirm: () => void;
+  mode: "removeProduct" | "clearCart";
 };
 
-export function DeleteConfirmation({
+export function ConfirmationPopup({
   open,
   onOpenChange,
   title,
   onConfirm,
+  mode,
 }: ConfirmDeleteDialogProps) {
+  const message =
+    mode === "removeProduct"
+      ? `Are you sure you want to remove ${title} from your cart?`
+      : "Are you sure you want to clear your cart?";
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <Dialog.Content aria-describedby={undefined}>
@@ -21,7 +27,7 @@ export function DeleteConfirmation({
         </Dialog.Header>
         <section className="flex flex-col gap-4 p-4">
           <section className="text-xl">
-            <Text>Are you sure you want to remove {title} from your cart?</Text>
+            <Text>{message}</Text>
           </section>
           <section className="flex flex-row gap-4 justify-end">
             <Dialog.Trigger asChild>

--- a/frontend/src/components/ConfirmationPopup/index.ts
+++ b/frontend/src/components/ConfirmationPopup/index.ts
@@ -1,0 +1,1 @@
+export { ConfirmationPopup } from "./ConfirmationPopup";

--- a/frontend/src/components/DeleteConfirmation/index.ts
+++ b/frontend/src/components/DeleteConfirmation/index.ts
@@ -1,1 +1,0 @@
-export { DeleteConfirmation } from "./DeleteConfirmation";

--- a/frontend/src/compositions/elements/EmptyCartButton.test.tsx
+++ b/frontend/src/compositions/elements/EmptyCartButton.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import { axe } from "vitest-axe";
+
+import * as CartContext from "@/context/CartContext";
+import { renderWithRouterAndProviders } from "@/lib/test/test-utils";
+
+import { EmptyCartButton } from "./EmptyCartButton";
+
+describe("Given a user is looking at their cart", () => {
+  describe("When the clear cart button is rendered", () => {
+    it("Then clicking on the button empties the cart", async () => {
+      const clearCartMock = vi.fn();
+
+      vi.spyOn(CartContext, "useCart").mockReturnValue({
+        clearCart: clearCartMock,
+      } as unknown as CartContext.CartContextType);
+
+      renderWithRouterAndProviders(<EmptyCartButton />);
+
+      const clearCartButton = screen.getByTestId("clear-cart-button");
+      fireEvent.click(clearCartButton);
+
+      const confirmButton = await screen.findByRole("button", {
+        name: /confirm/i,
+      });
+      expect(confirmButton).toBeInTheDocument();
+
+      await fireEvent.click(confirmButton);
+
+      expect(clearCartMock).toHaveBeenCalled();
+    });
+    it("Then it should have no accessibility violations", async () => {
+      const { container } = renderWithRouterAndProviders(<EmptyCartButton />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+});

--- a/frontend/src/compositions/elements/EmptyCartButton.tsx
+++ b/frontend/src/compositions/elements/EmptyCartButton.tsx
@@ -1,0 +1,56 @@
+import { Trash } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { Button, Dialog, Text } from "@/components/retroui";
+import { useCart } from "@/context/CartContext";
+
+export function EmptyCartButton() {
+  const { clearCart } = useCart();
+  const [openConfirmDelete, setOpenConfirmDelete] = useState(false);
+
+  const handleClearCart = () => {
+    clearCart();
+    toast.success("Cart has been emptied", {
+      richColors: true,
+    });
+  };
+
+  return (
+    <>
+      <Button
+        className="bg-destructive text-white hover:bg-destructive/90"
+        onClick={() => setOpenConfirmDelete(true)}
+        data-testid="clear-cart-button"
+      >
+        <Trash className="h-4 w-4 mr-2" /> Empty Cart
+      </Button>
+      <Dialog open={openConfirmDelete} onOpenChange={setOpenConfirmDelete}>
+        <Dialog.Content aria-describedby={undefined}>
+          <Dialog.Header position="fixed" asChild>
+            <Text as="h5">Confirm delete</Text>
+          </Dialog.Header>
+          <section className="flex flex-col gap-4 p-4">
+            <section className="text-xl">
+              <Text>Are you sure you want to clear your cart?</Text>
+              <Text>This action cannot be undone</Text>
+            </section>
+            <section className="flex flex-row gap-4 justify-end">
+              <Dialog.Trigger asChild>
+                <Button
+                  className="bg-destructive text-white hover:bg-destructive/90"
+                  onClick={handleClearCart}
+                >
+                  Confirm
+                </Button>
+              </Dialog.Trigger>
+              <Dialog.Trigger asChild>
+                <Button variant="outline">Cancel</Button>
+              </Dialog.Trigger>
+            </section>
+          </section>
+        </Dialog.Content>
+      </Dialog>
+    </>
+  );
+}

--- a/frontend/src/compositions/elements/EmptyCartButton.tsx
+++ b/frontend/src/compositions/elements/EmptyCartButton.tsx
@@ -2,15 +2,20 @@ import { Trash } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
-import { Button, Dialog, Text } from "@/components/retroui";
+import { handleCartAction } from "@/components/CartProductActions/utils/cartActions";
+import { ConfirmationPopup } from "@/components/ConfirmationPopup";
+import { Button } from "@/components/retroui";
 import { useCart } from "@/context/CartContext";
 
 export function EmptyCartButton() {
   const { clearCart } = useCart();
-  const [openConfirmDelete, setOpenConfirmDelete] = useState(false);
+  const [openConfirmClearCart, setOpenConfirmClearCart] = useState(false);
 
   const handleClearCart = () => {
-    clearCart();
+    handleCartAction({
+      action: "clearCart",
+      utilArgs: { clearCart },
+    });
     toast.success("Cart has been emptied", {
       richColors: true,
     });
@@ -20,37 +25,17 @@ export function EmptyCartButton() {
     <>
       <Button
         className="bg-destructive text-white hover:bg-destructive/90"
-        onClick={() => setOpenConfirmDelete(true)}
+        onClick={() => setOpenConfirmClearCart(true)}
         data-testid="clear-cart-button"
       >
         <Trash className="h-4 w-4 mr-2" /> Empty Cart
       </Button>
-      <Dialog open={openConfirmDelete} onOpenChange={setOpenConfirmDelete}>
-        <Dialog.Content aria-describedby={undefined}>
-          <Dialog.Header position="fixed" asChild>
-            <Text as="h5">Confirm delete</Text>
-          </Dialog.Header>
-          <section className="flex flex-col gap-4 p-4">
-            <section className="text-xl">
-              <Text>Are you sure you want to clear your cart?</Text>
-              <Text>This action cannot be undone</Text>
-            </section>
-            <section className="flex flex-row gap-4 justify-end">
-              <Dialog.Trigger asChild>
-                <Button
-                  className="bg-destructive text-white hover:bg-destructive/90"
-                  onClick={handleClearCart}
-                >
-                  Confirm
-                </Button>
-              </Dialog.Trigger>
-              <Dialog.Trigger asChild>
-                <Button variant="outline">Cancel</Button>
-              </Dialog.Trigger>
-            </section>
-          </section>
-        </Dialog.Content>
-      </Dialog>
+      <ConfirmationPopup
+        open={openConfirmClearCart}
+        onOpenChange={setOpenConfirmClearCart}
+        onConfirm={handleClearCart}
+        mode="clearCart"
+      />
     </>
   );
 }

--- a/frontend/src/pages/Cart/Cart.tsx
+++ b/frontend/src/pages/Cart/Cart.tsx
@@ -1,8 +1,9 @@
-import { ChevronLeft, Save, Trash } from "lucide-react";
+import { ChevronLeft, Save } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 
 import { Text } from "@/components/retroui";
 import { Button } from "@/components/retroui/Button";
+import { EmptyCartButton } from "@/compositions/elements/EmptyCartButton";
 import { IndividualSupermarketCart } from "@/compositions/IndividualSupermarketCart";
 import { useCart } from "@/context/CartContext";
 
@@ -22,9 +23,7 @@ export function Cart() {
             <Save className="h-4 w-4 mr-2" />
             Save To Clipboard
           </Button>
-          <Button className="bg-destructive text-white hover:bg-destructive/90">
-            <Trash className="h-4 w-4 mr-2" /> Empty Cart
-          </Button>
+          <EmptyCartButton />
         </span>
       </div>
 
@@ -49,10 +48,7 @@ export function Cart() {
             <Save className="h-4 w-4 mr-2" />
             Save To Clipboard
           </Button>
-          <Button className="bg-destructive text-white hover:bg-destructive/90">
-            <Trash className="h-4 w-4 mr-2" />
-            Empty Cart
-          </Button>
+          <EmptyCartButton />
         </div>
       </>
     </div>


### PR DESCRIPTION
<!-- Description of task purpose -->
Currently Empty Cart button is only a UI element and does not trigger any cart actions. Need to wire the button to `cartContext` function so clicking the button updates cart

Project ticket: #55 

### Acceptance Criteria
- [x] When clicked all items that were displayed on the cart page are removed and those items are no longer 'in cart'

### Discoveries
<!-- Anything to note/for others' understanding -->
- Used the confirmation popup from the delete. Updated so that it is reusable if we need more confirmation popups
- I discovered a NaN bug that - will deep dive into why the woolworths products bugged out
   - can see it in `calculateTotals.ts` - `getItemPrice` line 52/53 , when promo tag is applied but `item.product.price.value` is not a number
   - multibuy `5 for $100` not being a `number`
<img width="1233" height="965" alt="NaN bug" src="https://github.com/user-attachments/assets/5cc30e09-a1d5-437c-bf9f-d2a43c90d06c" />

Noted above bug in issue #173


### Testing
<!-- Notes on how to manual test, evidence of added tests passing with 80% coverage etc -->
<img width="734" height="35" alt="Screenshot 2025-09-02 165612" src="https://github.com/user-attachments/assets/617a6166-a36c-4786-8f26-2d72b462fb31" />


### Checklist
- [x] tests passing
- [x] applied relevant labels to PR ***(`chore`/`feat`/`fix` etc)***
- [x] added screenshots/recordings ***(if applicable)***


### Screenshots/Recordings ***(optional)***

https://github.com/user-attachments/assets/afe917ed-8f59-4869-a83b-0779313a5f39


