### PR TITLE
feat: #128 - fallback component

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -50,6 +50,7 @@
         "globals": "^16.3.0",
         "jsdom": "^26.1.0",
         "prettier": "^3.6.2",
+        "react-error-boundary": "^6.0.0",
         "react-router": "^7.7.0",
         "react-router-dom": "^7.7.0",
         "tw-animate-css": "^1.3.5",
@@ -7841,6 +7842,19 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.0.0.tgz",
+      "integrity": "sha512-gdlJjD7NWr0IfkPlaREN2d9uUZUlksrfOx7SX62VRerwXbMY6ftGCIZua1VG1aXFNOimhISsTq+Owp725b9SiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -58,6 +58,7 @@
     "globals": "^16.3.0",
     "jsdom": "^26.1.0",
     "prettier": "^3.6.2",
+    "react-error-boundary": "^6.0.0",
     "react-router": "^7.7.0",
     "react-router-dom": "^7.7.0",
     "tw-animate-css": "^1.3.5",

--- a/frontend/src/components/Fallback/Fallback.test.tsx
+++ b/frontend/src/components/Fallback/Fallback.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import { axe } from "vitest-axe";
+
+import { Fallback } from "@/components/Fallback";
+
+const error = new Error("Network request failed");
+
+describe("Given an error occurs", () => {
+  describe("When rendered", () => {
+    it("Then the user sees a warning with the error message", () => {
+      render(<Fallback error={error} />);
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(screen.getByText("Network request failed")).toBeInTheDocument();
+    });
+
+    it("Then it has no accessibility violations", async () => {
+      const { container } = render(<Fallback error={error} />);
+      const results = await axe(container, {
+        rules: {
+          "color-contrast": { enabled: false },
+        },
+      });
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  describe("When a custom message is provided", () => {
+    it("Then the user sees the custom friendly message", () => {
+      render(<Fallback message="Could not load supermarket products" />);
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(
+        screen.getByText("Could not load supermarket products"),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe("Given no specific error occurs", () => {
+  describe("When rendered", () => {
+    it("Then the user sees the default friendly message", () => {
+      render(<Fallback />);
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Something went wrong. Please try checking again later.",
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/Fallback/Fallback.tsx
+++ b/frontend/src/components/Fallback/Fallback.tsx
@@ -3,7 +3,7 @@ import { InfoIcon } from "lucide-react";
 import { Alert } from "@/components/retroui/Alert";
 
 type FallbackProps = {
-  error?: Error;
+  error?: Error | null;
   resetErrorBoundary?: () => void;
   message?: string;
 };

--- a/frontend/src/components/Fallback/Fallback.tsx
+++ b/frontend/src/components/Fallback/Fallback.tsx
@@ -1,0 +1,25 @@
+import { InfoIcon } from "lucide-react";
+
+import { Alert } from "@/components/retroui/Alert";
+
+type FallbackProps = {
+  error?: Error;
+  resetErrorBoundary?: () => void;
+  message?: string;
+};
+
+export function Fallback({ error, message }: FallbackProps) {
+  const fallbackMessage = message
+    ? message
+    : "Something went wrong. Please try checking again later.";
+  return (
+    <Alert
+      status="warning"
+      className="flex items-center max-h-32 overflow-auto p-4"
+    >
+      <InfoIcon className="h-4 w-4 mr-3" />
+
+      <Alert.Title>{error?.message ?? fallbackMessage}</Alert.Title>
+    </Alert>
+  );
+}

--- a/frontend/src/components/Fallback/WithErrorBoundary.tsx
+++ b/frontend/src/components/Fallback/WithErrorBoundary.tsx
@@ -1,0 +1,41 @@
+import type { ComponentType, ErrorInfo } from "react";
+import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
+
+import { Fallback } from "@/components/Fallback";
+
+type WithErrorBoundaryOptions = {
+  message?: string;
+  onReset?: () => void;
+  onError?: (error: Error, info: ErrorInfo) => void;
+  FallbackComponent?: ComponentType<FallbackProps>;
+};
+
+export function withErrorBoundary<P extends object>(
+  WrappedComponent: ComponentType<P>,
+  options: WithErrorBoundaryOptions = {},
+) {
+  const { message, onReset, onError, FallbackComponent } = options;
+
+  function WithErrorBoundary(props: P) {
+    return (
+      <ErrorBoundary
+        FallbackComponent={(fallbackProps) => {
+          if (FallbackComponent) {
+            return <FallbackComponent {...fallbackProps} />;
+          }
+          return <Fallback error={fallbackProps.error} message={message} />;
+        }}
+        onReset={onReset}
+        onError={onError}
+      >
+        <WrappedComponent {...props} />
+      </ErrorBoundary>
+    );
+  }
+
+  const wrappedName =
+    WrappedComponent.displayName || WrappedComponent.name || "Component";
+  WithErrorBoundary.displayName = `withErrorBoundary(${wrappedName})`;
+
+  return WithErrorBoundary;
+}

--- a/frontend/src/components/Fallback/index.ts
+++ b/frontend/src/components/Fallback/index.ts
@@ -1,0 +1,1 @@
+export { Fallback } from "./Fallback";

--- a/frontend/src/components/Fallback/withErrorBoundary.test.tsx
+++ b/frontend/src/components/Fallback/withErrorBoundary.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { vi } from "vitest";
+
+import { withErrorBoundary } from "./WithErrorBoundary";
+
+// Normal component that renders fine
+const NormalComponent: React.FC = () => <div>All good!</div>;
+
+// Component that throws an error
+const BuggyComponent: React.FC = () => {
+  throw new Error("Boom!");
+};
+
+// Mock fallback component
+const MockFallback: React.FC<{ error: Error }> = ({ error }) => (
+  <div data-testid="mock-fallback">{error.message}</div>
+);
+
+describe("withErrorBoundary HOC", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeAll(() => {
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe("Given a component that loads successfully", () => {
+    describe("When it renders", () => {
+      it("Then the user sees the component content", () => {
+        const SafeComponent = withErrorBoundary(NormalComponent);
+        render(<SafeComponent />);
+        expect(screen.getByText("All good!")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Given a component that throws an error", () => {
+    describe("When it renders", () => {
+      it("Then the HOC displays the provided fallback", () => {
+        const SafeBuggy = withErrorBoundary(BuggyComponent, {
+          FallbackComponent: MockFallback,
+        });
+        render(<SafeBuggy />);
+        expect(screen.getByTestId("mock-fallback")).toHaveTextContent("Boom!");
+      });
+    });
+
+    describe("When a different fallback is provided", () => {
+      it("Then the HOC renders the correct fallback", () => {
+        const AnotherFallback: React.FC<{ error: Error }> = ({ error }) => (
+          <div data-testid="another-fallback">Oops: {error.message}</div>
+        );
+        const SafeBuggyCustom = withErrorBoundary(BuggyComponent, {
+          FallbackComponent: AnotherFallback,
+        });
+        render(<SafeBuggyCustom />);
+        expect(screen.getByTestId("another-fallback")).toHaveTextContent(
+          "Oops: Boom!",
+        );
+      });
+    });
+  });
+});

--- a/frontend/src/components/ProductColumn/ProductColumn.test.tsx
+++ b/frontend/src/components/ProductColumn/ProductColumn.test.tsx
@@ -4,53 +4,79 @@ import { axe } from "vitest-axe";
 
 import {
   mockEmptyMarketResult,
+  mockErrorMarketResult,
   mockMarketResult,
 } from "@/lib/test/fixtures/marketResult";
 import { renderWithRouterAndProviders } from "@/lib/test/test-utils";
 
-import { ProductColumn } from "./ProductColumn";
+import { ProductColumnWithErrorBoundary } from "./ProductColumn";
 
-vi.mock("../Card", () => ({
-  Card: () => <div data-testid="card-component">Mocked Card</div>,
+vi.mock("@/components/Card", () => ({
+  Card: () => <div data-testid="mock-card-component">Mocked Card</div>,
 }));
 
-describe("Given a user is looking at an individual supermarkets product column ", () => {
+vi.mock("@/components/Fallback", () => ({
+  Fallback: () => (
+    <div data-testid="mock-fallback-component">Fallback Component</div>
+  ),
+}));
+
+describe("Given a user is looking at an individual supermarkets product column", () => {
   describe("When the product grid is displayed in the supermarket column", () => {
     it("Then the heading of the column is the supermarket name", () => {
-      renderWithRouterAndProviders(<ProductColumn {...mockMarketResult} />);
+      renderWithRouterAndProviders(
+        <ProductColumnWithErrorBoundary {...mockMarketResult} />,
+      );
 
       const heading = screen.getByRole("heading", { level: 2 });
       expect(heading).toBeInTheDocument();
       expect(heading).toHaveTextContent(/new world/i);
     });
-    it("Then all the product cards for that supermarket are displayed", () => {
-      renderWithRouterAndProviders(<ProductColumn {...mockMarketResult} />);
 
-      const supermarketProducts = screen.getAllByTestId("card-component");
+    it("Then all the product cards for that supermarket are displayed", () => {
+      renderWithRouterAndProviders(
+        <ProductColumnWithErrorBoundary {...mockMarketResult} />,
+      );
+
+      const supermarketProducts = screen.getAllByTestId("mock-card-component");
       expect(supermarketProducts).toHaveLength(11);
     });
+
     it("Then it displays the product cards in a 2 column grid", () => {
-      renderWithRouterAndProviders(<ProductColumn {...mockMarketResult} />);
+      renderWithRouterAndProviders(
+        <ProductColumnWithErrorBoundary {...mockMarketResult} />,
+      );
 
       const productGridDiv = screen.getByTestId("product-grid");
       expect(productGridDiv).toHaveClass("grid grid-cols-2");
     });
+
     it("Then it has no accessibility violations", async () => {
       const { container } = renderWithRouterAndProviders(
-        <ProductColumn {...mockMarketResult} />,
+        <ProductColumnWithErrorBoundary {...mockMarketResult} />,
       );
       const results = await axe(container);
       expect(results).toHaveNoViolations();
     });
   });
-  describe("When there are no product results to display", () => {
-    it("Then a user sees a no products message", () => {
+
+  describe("When the product result request is succesful but there are no product results to display", () => {
+    it("Then the user sees a 'no products' message", () => {
       renderWithRouterAndProviders(
-        <ProductColumn {...mockEmptyMarketResult} />,
+        <ProductColumnWithErrorBoundary {...mockEmptyMarketResult} />,
       );
       expect(
         screen.getByText(/No product results to display/i),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe("When the product result request failed", () => {
+    it("Then the user sees the fallback UI", () => {
+      renderWithRouterAndProviders(
+        <ProductColumnWithErrorBoundary {...mockErrorMarketResult} />,
+      );
+      expect(screen.getByText(/Fallback component/i)).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/ProductColumn/ProductColumn.tsx
+++ b/frontend/src/components/ProductColumn/ProductColumn.tsx
@@ -1,7 +1,8 @@
+import { Card } from "@/components/Card";
+import { Fallback } from "@/components/Fallback";
+import { withErrorBoundary } from "@/components/Fallback/WithErrorBoundary";
+import { Text } from "@/components/retroui";
 import { supermarketTitles } from "@/lib/constants";
-
-import { Card } from "../Card";
-import { Text } from "../retroui";
 
 type ProductColumnProps = {
   marketResult: SearchData;
@@ -19,7 +20,12 @@ export function ProductColumn({ marketResult, shopCode }: ProductColumnProps) {
   }
 
   if (error) {
-    return <p>Error</p>;
+    return (
+      <Fallback
+        error={error}
+        message="Something went wrong while fetching products. Please try again later."
+      />
+    );
   }
 
   return (
@@ -53,3 +59,8 @@ export function ProductColumn({ marketResult, shopCode }: ProductColumnProps) {
     </div>
   );
 }
+
+export const ProductColumnWithErrorBoundary = withErrorBoundary(ProductColumn, {
+  message: "Unable to display products for this store",
+  FallbackComponent: Fallback,
+});

--- a/frontend/src/components/ProductColumn/ProductColumn.tsx
+++ b/frontend/src/components/ProductColumn/ProductColumn.tsx
@@ -9,7 +9,7 @@ type ProductColumnProps = {
   shopCode: ShopCode;
 };
 
-export function ProductColumn({ marketResult, shopCode }: ProductColumnProps) {
+function ProductColumn({ marketResult, shopCode }: ProductColumnProps) {
   const { data, isLoading, error } = marketResult;
 
   const supermarketName = supermarketTitles[shopCode];

--- a/frontend/src/components/ProductColumn/index.ts
+++ b/frontend/src/components/ProductColumn/index.ts
@@ -1,1 +1,1 @@
-export { ProductColumn, ProductColumnWithErrorBoundary } from "./ProductColumn";
+export { ProductColumnWithErrorBoundary } from "./ProductColumn";

--- a/frontend/src/components/ProductColumn/index.ts
+++ b/frontend/src/components/ProductColumn/index.ts
@@ -1,1 +1,1 @@
-export { ProductColumn } from "./ProductColumn";
+export { ProductColumn, ProductColumnWithErrorBoundary } from "./ProductColumn";

--- a/frontend/src/components/retroui/Alert.tsx
+++ b/frontend/src/components/retroui/Alert.tsx
@@ -1,0 +1,56 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import type { HtmlHTMLAttributes } from "react";
+
+import { Text } from "@/components/retroui/Text";
+import { cn } from "@/lib/retroui.utils";
+
+const alertVariants = cva("relative w-full border-2 p-4", {
+  variants: {
+    variant: {
+      default: "bg-background text-foreground",
+      solid: "bg-black text-white",
+    },
+    status: {
+      error: "bg-red-300 text-red-800 border-red-800",
+      success: "bg-green-300 text-green-800 border-green-800",
+      warning: "bg-yellow-300 text-yellow-800 border-yellow-800",
+      info: "bg-blue-300 text-blue-800 border-blue-800",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+  },
+});
+
+interface IAlertProps
+  extends HtmlHTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof alertVariants> {}
+
+const Alert = ({ className, variant, status, ...props }: IAlertProps) => (
+  <div
+    role="alert"
+    className={cn(alertVariants({ variant, status }), className)}
+    {...props}
+  />
+);
+Alert.displayName = "Alert";
+
+type IAlertTitleProps = HtmlHTMLAttributes<HTMLHeadingElement>;
+const AlertTitle = ({ className, ...props }: IAlertTitleProps) => (
+  <Text as="h5" className={cn(className)} {...props} />
+);
+AlertTitle.displayName = "AlertTitle";
+
+type IAlertDescriptionProps = HtmlHTMLAttributes<HTMLParagraphElement>;
+const AlertDescription = ({ className, ...props }: IAlertDescriptionProps) => (
+  <div className={cn("text-muted-foreground", className)} {...props} />
+);
+
+AlertDescription.displayName = "AlertDescription";
+
+const AlertComponent = Object.assign(Alert, {
+  Title: AlertTitle,
+  Description: AlertDescription,
+});
+
+export { AlertComponent as Alert };

--- a/frontend/src/components/retroui/index.tsx
+++ b/frontend/src/components/retroui/index.tsx
@@ -1,3 +1,4 @@
+export * from "./Alert";
 export * from "./Button";
 export * from "./Card";
 export * from "./Dialog";

--- a/frontend/src/lib/test/fixtures/marketResult.ts
+++ b/frontend/src/lib/test/fixtures/marketResult.ts
@@ -1,9 +1,10 @@
 import { nwData } from "./nw_actual";
 
+// ----- SUCCESS -----
 const mockMarketResultData: SearchData = {
   data: nwData as Product[],
   isLoading: false,
-  error: undefined,
+  error: null,
 };
 
 export const mockMarketResult = {
@@ -11,13 +12,26 @@ export const mockMarketResult = {
   shopCode: "nw" as ShopCode,
 };
 
+// ----- EMPTY SUCCESS -----
 const mockMarketResultEmptyData: SearchData = {
   data: [] as Product[],
   isLoading: false,
-  error: undefined,
+  error: null,
 };
 
 export const mockEmptyMarketResult = {
   marketResult: mockMarketResultEmptyData,
+  shopCode: "nw" as ShopCode,
+};
+
+// ----- ERROR -----
+const mockMarketResultError: SearchData = {
+  data: [] as Product[],
+  isLoading: false,
+  error: { name: "Error:", message: "Mock error message" },
+};
+
+export const mockErrorMarketResult = {
+  marketResult: mockMarketResultError,
   shopCode: "nw" as ShopCode,
 };

--- a/frontend/src/pages/Browse/Browse.test.tsx
+++ b/frontend/src/pages/Browse/Browse.test.tsx
@@ -7,8 +7,10 @@ import { renderWithRouterAndProviders } from "@/lib/test/test-utils";
 import { Browse } from "./Browse";
 
 vi.mock("@/components/ProductColumn", () => ({
-  ProductColumn: () => (
-    <div data-testid="supermarket-container">Mocked ProductColumn</div>
+  ProductColumnWithErrorBoundary: () => (
+    <div data-testid="supermarket-container">
+      Mocked ProductColumn component
+    </div>
   ),
 }));
 

--- a/frontend/src/pages/Browse/Browse.tsx
+++ b/frontend/src/pages/Browse/Browse.tsx
@@ -1,4 +1,4 @@
-import { ProductColumn } from "@/components/ProductColumn";
+import { ProductColumnWithErrorBoundary } from "@/components/ProductColumn";
 import { SearchBar } from "@/components/SearchBar";
 import { useSearch } from "@/context/SearchContext";
 
@@ -15,7 +15,7 @@ export function Browse() {
 
       <div className="browse-container grid grid-cols-3 divide-x divide-gray-600">
         {Object.entries(results).map(([shopCode, marketResult]) => (
-          <ProductColumn
+          <ProductColumnWithErrorBoundary
             key={shopCode}
             marketResult={marketResult}
             shopCode={shopCode as ShopCode}

--- a/frontend/src/types/Supermarket.types.d.ts
+++ b/frontend/src/types/Supermarket.types.d.ts
@@ -3,7 +3,7 @@ type ShopCode = "nw" | "pns" | "wls";
 type SearchData = {
   data: Product[];
   isLoading: boolean;
-  error: unknown;
+  error: Error | null;
 };
 
 type MarketResults = Record<ShopCode, SearchData>;


### PR DESCRIPTION
<!-- Description of task purpose -->
Fallback component to use to have a nice consistent ui for errors to show users. 

Added `withErrorBoundary` to capture runtime rendering issues and use fallback UI to display error to users. 
Used `withErrorBoundary` to wrap ProductColumn

Project ticket: #128 

### Acceptance Criteria
- [x] fallback component to display error messages

### Discoveries
<!-- Anything to note/for others' understanding -->

### Testing
<!-- Notes on how to manual test, evidence of added tests passing with 80% coverage etc -->

**Added tests:** 

<img width="630" height="48" alt="Screenshot 2025-09-02 at 5 04 07 PM" src="https://github.com/user-attachments/assets/14f79224-330b-4905-ab2d-aae9a6aa1a6b" />

**Edited tests:** 

<img width="599" height="34" alt="Screenshot 2025-09-02 at 5 04 33 PM" src="https://github.com/user-attachments/assets/1cbe91bb-0b4a-4bef-8066-20afbbe8eb05" />
<img width="652" height="34" alt="Screenshot 2025-09-02 at 5 04 19 PM" src="https://github.com/user-attachments/assets/82b7b1f1-08cd-410c-80d5-b557f3020ad1" />


### Checklist
- [x] tests passing
- [x] applied relevant labels to PR ***(`chore`/`feat`/`fix` etc)***
- [x] added screenshots/recordings ***(if applicable)***


### Screenshots/Recordings ***(optional)***

**Example of fallback UI with fallback error message**

<img width="433" height="51" alt="Screenshot 2025-09-02 at 5 07 45 PM" src="https://github.com/user-attachments/assets/38be170a-6f29-4704-be61-fde79df4fb80" />

