### PR TITLE
fix: #181 - woolworths per kg return

### DIFF
--- a/backend/app/services/woolworths_parser.rb
+++ b/backend/app/services/woolworths_parser.rb
@@ -217,7 +217,7 @@ class WoolworthsParser
 
     promo[:tag] = get_tag(node)
 
-    promo[:value] = current_price[:value]
+    promo[:value] = current_price[:value][/\d+(\.\d+)?/]
     promo[:per] = current_price[:per]
     promo[:unitPrice] = nil
     promo[:unit] = nil


### PR DESCRIPTION
<!-- Description of task purpose -->
Currently items that are '$x.xx per kg' return `$x kg `instead of just the number value so it is also returning a NaN value

Project ticket: #181 

### Acceptance Criteria
- [x] update return to just include the number value

### Discoveries
<!-- Anything to note/for others' understanding -->
- The issue was in the Promo Special return so only that one return value needed updating

### Testing
<!-- Notes on how to manual test, evidence of added tests passing with 80% coverage etc -->

### Checklist
- [x] tests passing
- [x] applied relevant labels to PR ***(`chore`/`feat`/`fix` etc)***
- [ ] added screenshots/recordings ***(if applicable)***


### Screenshots/Recordings ***(optional)***
