### PR TITLE
chore #176 - capitalise product titles

### DIFF
--- a/backend/app/helpers/str_utils.rb
+++ b/backend/app/helpers/str_utils.rb
@@ -1,0 +1,14 @@
+class StrUtils
+  def self.to_title_case(str)
+    special_cases = {
+      "nz" => "NZ",
+      "x" => "x",
+    }
+
+    str.split.map { |word| special_cases[word] || capitalise(word) }.join(" ")
+  end
+
+  def self.capitalise(str)
+    str[0].upcase + str[1..]
+  end
+end

--- a/backend/app/helpers/str_utils.rb
+++ b/backend/app/helpers/str_utils.rb
@@ -3,6 +3,11 @@ class StrUtils
     special_cases = {
       "nz" => "NZ",
       "x" => "x",
+      "ea" => "ea",
+      "ea." => "ea.",
+      "ml" => "mL",
+      "kg" => "kg",
+      "g" => "g",
     }
 
     str.split.map { |word| special_cases[word] || capitalise(word) }.join(" ")

--- a/backend/app/services/new_world_parser.rb
+++ b/backend/app/services/new_world_parser.rb
@@ -36,7 +36,7 @@ class NewWorldParser
     {
       supermarket: "nw",
       id: extract_id(node),
-      title: product_title,
+      title: StrUtils.to_title_case(product_title),
       image: extract_image(node),
       productPageUrl: extract_product_page_url(node),
       price: extract_price(node),

--- a/backend/app/services/paknsave_parser.rb
+++ b/backend/app/services/paknsave_parser.rb
@@ -36,7 +36,7 @@ class PaknsaveParser
     {
       supermarket: "pns",
       id: extract_id(node),
-      title: product_title,
+      title: StrUtils.to_title_case(product_title),
       image: extract_img(node),
       productPageUrl: extract_product_page_url(node),
       price: extract_price(node),

--- a/backend/app/services/woolworths_parser.rb
+++ b/backend/app/services/woolworths_parser.rb
@@ -41,7 +41,7 @@ class WoolworthsParser
     {
       supermarket: "wls",
       id: extract_id(node),
-      title: title,
+      title: title.titleize,
       image: extract_image(node),
       productPageUrl: extract_product_page_url(node),
       price: ticketed_prices[:price],

--- a/backend/app/services/woolworths_parser.rb
+++ b/backend/app/services/woolworths_parser.rb
@@ -41,7 +41,7 @@ class WoolworthsParser
     {
       supermarket: "wls",
       id: extract_id(node),
-      title: title.titleize,
+      title: StrUtils.to_title_case(title),
       image: extract_image(node),
       productPageUrl: extract_product_page_url(node),
       price: ticketed_prices[:price],

--- a/backend/spec/fixtures/pns_curated.rb
+++ b/backend/spec/fixtures/pns_curated.rb
@@ -23,7 +23,7 @@ module MockTestData
   PNS_LIMIT_OBJ = {
     supermarket: "pns",
     id: "5236273",
-    title: "Karicare 1 Baby Infant Formula From Birth to 6 Months 900g",
+    title: "Karicare 1 Baby Infant Formula From Birth To 6 Months 900g",
     image: "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5236273.png?w=384",
     productPageUrl: "https://www.paknsave.co.nz/shop/product/5236273_ea_000pns?name=karicare-1-baby-infant-formula-from-birth-to-6-months",
     price: {

--- a/backend/spec/fixtures/wls_curated.rb
+++ b/backend/spec/fixtures/wls_curated.rb
@@ -2,7 +2,7 @@ module MockTestData
   WLS_MEMBER_PRICE_OBJ = {
     supermarket: "wls",
     id: "139864",
-    title: "v vitalise energy drink guarana Single can 250mL",
+    title: "V Vitalise Energy Drink Guarana Single Can 250mL",
     image: "https://assets.woolworths.com.au/images/2010/139864.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl: "https://www.woolworths.co.nz/shop/productdetails?stockcode=139864&name=v-vitalise-energy-drink-guarana",
     price: {
@@ -23,7 +23,7 @@ module MockTestData
   WLS_NORMAL_OBJ = {
     supermarket: "wls",
     id: "132815",
-    title: "v vitalise energy drink 250ml Can 4pack",
+    title: "V Vitalise Energy Drink 250ml Can 4pack",
     image: "https://assets.woolworths.com.au/images/2010/132815.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl: "https://www.woolworths.co.nz/shop/productdetails?stockcode=132815&name=v-vitalise-energy-drink-250ml",
     price: {
@@ -38,7 +38,7 @@ module MockTestData
   WLS_SPECIAL_OBJ = {
     supermarket: "wls",
     id: "315692",
-    title: "v vitalise energy drink Single can 500mL",
+    title: "V Vitalise Energy Drink Single Can 500mL",
     image: "https://assets.woolworths.com.au/images/2010/315692.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl: "https://www.woolworths.co.nz/shop/productdetails?stockcode=315692&name=v-vitalise-energy-drink",
     price: {
@@ -59,7 +59,7 @@ module MockTestData
   WLS_LOW_PRICE_OBJ = {
     supermarket: "wls",
     id: "98508",
-    title: "turks free range chicken breast skinless fillet 450g",
+    title: "Turks Free Range Chicken Breast Skinless Fillet 450g",
     image: "https://assets.woolworths.com.au/images/2010/98508.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl: "https://www.woolworths.co.nz/shop/productdetails?stockcode=98508&name=turks-free-range-chicken-breast-skinless-fillet",
     price: {
@@ -76,7 +76,7 @@ module MockTestData
   WLS_SPECIAL_MULTI_BUY_OBJ = {
     supermarket: "wls",
     id: "344618",
-    title: "woolworths chicken whole Each 1.35kg",
+    title: "Woolworths Chicken Whole Each 1.35kg",
     image: "https://assets.woolworths.com.au/images/2010/344618.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl: "https://www.woolworths.co.nz/shop/productdetails?stockcode=344618&name=woolworths-chicken-whole",
     price: {
@@ -97,7 +97,7 @@ module MockTestData
   WLS_DISNEY_DISC_SPECIAL_OBJ = {
     supermarket: "wls",
     id: "363271",
-    title: "tegel meal maker free range shredded roast chicken 100g 2 x 50g pks",
+    title: "Tegel Meal Maker Free Range Shredded Roast Chicken 100g 2 x 50g Pks",
     image: "https://assets.woolworths.com.au/images/2010/363271.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl: "https://www.woolworths.co.nz/shop/productdetails?stockcode=363271&name=tegel-meal-maker-free-range-shredded-roast-chicken",
     price: {
@@ -118,7 +118,7 @@ module MockTestData
   WLS_LOW_PRICE_MULTI_BUY_OBJ = {
     supermarket: "wls",
     id: "251463",
-    title: "woolworths NZ chicken mince breast 3% fat barn raised Tray 400g",
+    title: "Woolworths NZ Chicken Mince Breast 3% Fat Barn Raised Tray 400g",
     image: "https://assets.woolworths.com.au/images/2010/251463.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl: "https://www.woolworths.co.nz/shop/productdetails?stockcode=251463&name=woolworths-nz-chicken-mince-breast-3-fat-barn-raised",
     price: {
@@ -139,7 +139,7 @@ module MockTestData
   WLS_DISNEY_DISC_OBJ = {
     supermarket: "wls",
     id: "6014370",
-    title: "tegel free range quick cook chicken steaks chargrilled 4pk 400g",
+    title: "Tegel Free Range Quick Cook Chicken Steaks Chargrilled 4pk 400g",
     image: "https://assets.woolworths.com.au/images/2010/6014370.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl: "https://www.woolworths.co.nz/shop/productdetails?stockcode=6014370&name=tegel-free-range-quick-cook-chicken-steaks-chargrilled",
     price: {
@@ -156,7 +156,7 @@ module MockTestData
   WLS_FRESH_DEAL_MULTI_BUY_OBJ = {
     supermarket: "wls",
     id: "281082",
-    title: "fresh vegetable broccoli head",
+    title: "Fresh Vegetable Broccoli Head",
     image: "https://assets.woolworths.com.au/images/2010/281082.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl: "https://www.woolworths.co.nz/shop/productdetails?stockcode=281082&name=fresh-vegetable-broccoli-head",
     price: {
@@ -177,7 +177,7 @@ module MockTestData
   WLS_UNITLESS_PROMO_OBJ = {
     supermarket: "wls",
     id: "705958",
-    title: "speight's summit beer lager ultra low carb Bottle 24x330mL",
+    title: "Speight's Summit Beer Lager Ultra Low Carb Bottle 24x330mL",
     image: "https://assets.woolworths.com.au/images/2010/705958.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl: "https://www.woolworths.co.nz/shop/productdetails?stockcode=705958&name=speights-summit-beer-lager-ultra-low-carb",
     price: {
@@ -198,7 +198,7 @@ module MockTestData
   WLS_UNITLESS_OBJ = {
     supermarket: "wls",
     id: "907038",
-    title: "speight's gold medal beer ale Bottle 24x330mL",
+    title: "Speight's Gold Medal Beer Ale Bottle 24x330mL",
     image: "https://assets.woolworths.com.au/images/2010/907038.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl: "https://www.woolworths.co.nz/shop/productdetails?stockcode=907038&name=speights-gold-medal-beer-ale",
     price: {

--- a/frontend/src/context/CartContext.test.tsx
+++ b/frontend/src/context/CartContext.test.tsx
@@ -54,7 +54,7 @@ describe("Given a user has an empty cart", () => {
 
       expect(itemInCart).toBeDefined();
       expect(itemInCart.product.title).toBe(
-        "v vitalise energy drink 250ml Can 4pack",
+        "V Vitalise Energy Drink 250ml Can 4pack",
       );
     });
 

--- a/frontend/src/context/utils/cartData.ts
+++ b/frontend/src/context/utils/cartData.ts
@@ -225,7 +225,7 @@ const devInitialCart: CombinedCart = {
       quantity: 2,
       product: {
         id: "6030021",
-        title: "riley coffee beans heyday 500g",
+        title: "Riley Coffee Beans Heyday 500g",
         image:
           "https://assets.woolworths.com.au/images/2010/6030021.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
         productPageUrl:
@@ -248,7 +248,7 @@ const devInitialCart: CombinedCart = {
       quantity: 10,
       product: {
         id: "956132",
-        title: "whittakers chocolate block raspberry & NZ strawberry 100g",
+        title: "Whittakers Chocolate Block Raspberry & NZ Strawberry 100g",
         image:
           "https://assets.woolworths.com.au/images/2010/956132.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
         productPageUrl:
@@ -271,7 +271,7 @@ const devInitialCart: CombinedCart = {
       quantity: 1,
       product: {
         id: "253877",
-        title: "macro eggs free range mixed grade Carton 12pack",
+        title: "Macro Eggs Free Range Mixed Grade Carton 12pack",
         image:
           "https://assets.woolworths.com.au/images/2010/253877.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
         productPageUrl:
@@ -292,7 +292,7 @@ const devInitialCart: CombinedCart = {
       quantity: 5,
       product: {
         id: "281809",
-        title: "woolworths cheese edam Block 1kg",
+        title: "Woolworths Cheese Edam Block 1kg",
         image:
           "https://assets.woolworths.com.au/images/2010/281809.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
         productPageUrl:
@@ -311,7 +311,7 @@ const devInitialCart: CombinedCart = {
       quantity: 1,
       product: {
         id: "266023",
-        title: "watties spaghetti in tomato sauce Cans 3pack",
+        title: "Watties Spaghetti In Tomato Sauce Cans 3pack",
         image:
           "https://assets.woolworths.com.au/images/2010/266023.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
         productPageUrl:
@@ -332,7 +332,7 @@ const devInitialCart: CombinedCart = {
       quantity: 1,
       product: {
         id: "74613",
-        title: "la molisana pasta spaghetti 500g",
+        title: "La Molisana Pasta Spaghetti 500g",
         image:
           "https://assets.woolworths.com.au/images/2010/74613.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
         productPageUrl:

--- a/frontend/src/lib/clipboard.test.ts
+++ b/frontend/src/lib/clipboard.test.ts
@@ -39,7 +39,7 @@ describe("Given a user has items in their cart", () => {
       writeToClipboard(fullCartSimple);
 
       expect(mockWriteToClipboard).toHaveBeenCalledWithPartialStr(
-        "- speight's gold medal beer ale Bottle 24x330mL (x1)",
+        "- Speight's Gold Medal Beer Ale Bottle 24x330mL (x1)",
       );
       expect(mockWriteToClipboard).toHaveBeenCalledWithPartialStr(
         "- Chia Sisters Gut Lemon & Golden Kiwifruit Sparkling Drink 250ml (x4)",

--- a/frontend/src/lib/test/fixtures/clipboardCarts.ts
+++ b/frontend/src/lib/test/fixtures/clipboardCarts.ts
@@ -11,10 +11,10 @@ PAK'nSAVE:
 - Speight's Summit Ultra Low Carb Larger Beer Cans 24 x 330ml (x7)
 
 Woolworths:
-- turks free range chicken breast skinless fillet 450g (x4)
-- v vitalise energy drink 250ml Can 4pack (x2)
-- speight's gold medal beer ale Bottle 24x330mL (x1)
-- tegel free range quick cook chicken steaks chargrilled 4pk 400g (x2)
+- Turks Free Range Chicken Breast Skinless Fillet 450g (x4)
+- V Vitalise Energy Drink 250ml Can 4pack (x2)
+- Speight's Gold Medal Beer Ale Bottle 24x330mL (x1)
+- Tegel Free Range Quick Cook Chicken Steaks Chargrilled 4pk 400g (x2)
 `;
 
 export const partialCartStr = `New World:

--- a/frontend/src/lib/test/fixtures/nw_actual.ts
+++ b/frontend/src/lib/test/fixtures/nw_actual.ts
@@ -18,7 +18,7 @@ export const nwData: Product[] = [
   {
     id: "5330062",
     supermarket: "nw",
-    title: "eg. Free Range Jumbo Tray Eggs 20pk",
+    title: "Eg. Free Range Jumbo Tray Eggs 20pk",
     image:
       "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5330062.png?w=384",
     productPageUrl:
@@ -34,7 +34,7 @@ export const nwData: Product[] = [
   {
     id: "5330060",
     supermarket: "nw",
-    title: "eg. Free Range  Jumbo Eggs 6pk",
+    title: "Eg. Free Range Jumbo Eggs 6pk",
     image:
       "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5330060.png?w=384",
     productPageUrl:
@@ -50,7 +50,7 @@ export const nwData: Product[] = [
   {
     id: "5330059",
     supermarket: "nw",
-    title: "eg. Free Range Mixed Grade Eggs 6pk",
+    title: "Eg. Free Range Mixed Grade Eggs 6pk",
     image:
       "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5330059.png?w=384",
     productPageUrl:
@@ -66,7 +66,7 @@ export const nwData: Product[] = [
   {
     id: "5330058",
     supermarket: "nw",
-    title: "eg. Free Range Size 7 Tray Eggs 20pk",
+    title: "Eg. Free Range Size 7 Tray Eggs 20pk",
     image:
       "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5330058.png?w=384",
     productPageUrl:
@@ -82,7 +82,7 @@ export const nwData: Product[] = [
   {
     id: "5322431",
     supermarket: "nw",
-    title: "eg. Free Range Size 7 Eggs 20pk",
+    title: "Eg. Free Range Size 7 Eggs 20pk",
     image:
       "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5322431.png?w=384",
     productPageUrl:
@@ -98,7 +98,7 @@ export const nwData: Product[] = [
   {
     id: "5322430",
     supermarket: "nw",
-    title: "eg. Free Range Size 7 Eggs 6pk",
+    title: "Eg. Free Range Size 7 Eggs 6pk",
     image:
       "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5322430.png?w=384",
     productPageUrl:
@@ -114,7 +114,7 @@ export const nwData: Product[] = [
   {
     id: "5322429",
     supermarket: "nw",
-    title: "eg. Free Range Size 7 Eggs 12pk",
+    title: "Eg. Free Range Size 7 Eggs 12pk",
     image:
       "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5322429.png?w=384",
     productPageUrl:
@@ -130,7 +130,7 @@ export const nwData: Product[] = [
   {
     id: "5322428",
     supermarket: "nw",
-    title: "eg. Mixed Grade Free Range Eggs 20pk",
+    title: "Eg. Mixed Grade Free Range Eggs 20pk",
     image:
       "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5322428.png?w=384",
     productPageUrl:
@@ -146,7 +146,7 @@ export const nwData: Product[] = [
   {
     id: "5322427",
     supermarket: "nw",
-    title: "eg. Mixed Grade Free Range Eggs 12pk",
+    title: "Eg. Mixed Grade Free Range Eggs 12pk",
     image:
       "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5322427.png?w=384",
     productPageUrl:
@@ -162,7 +162,7 @@ export const nwData: Product[] = [
   {
     id: "5322426",
     supermarket: "nw",
-    title: "eg. Mixed Grade Free Range Eggs 20pk",
+    title: "Eg. Mixed Grade Free Range Eggs 20pk",
     image:
       "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5322426.png?w=384",
     productPageUrl:

--- a/frontend/src/lib/test/fixtures/pns_actual.ts
+++ b/frontend/src/lib/test/fixtures/pns_actual.ts
@@ -70,7 +70,7 @@ export const pnsData: Product[] = [
   {
     id: "5329222",
     supermarket: "pns",
-    title: "Dairyworks Tasty Natural Cheese and Griffins Snax Crackers 4 x 30g",
+    title: "Dairyworks Tasty Natural Cheese And Griffins Snax Crackers 4 x 30g",
     image:
       "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5329222.png?w=384",
     productPageUrl:

--- a/frontend/src/lib/test/fixtures/products/pnsProducts.ts
+++ b/frontend/src/lib/test/fixtures/products/pnsProducts.ts
@@ -78,7 +78,7 @@ export const pnsProductPromoTagUnitless = {
 
 export const pnsProductPromoWithLimit = {
   id: "5236273",
-  title: "Karicare 1 Baby Infant Formula From Birth to 6 Months 900g",
+  title: "Karicare 1 Baby Infant Formula From Birth To 6 Months 900g",
   image:
     "https://a.fsimg.co.nz/product/retail/fan/image/400x400/5236273.png?w=384",
   productPageUrl:

--- a/frontend/src/lib/test/fixtures/products/wlsProducts.ts
+++ b/frontend/src/lib/test/fixtures/products/wlsProducts.ts
@@ -4,7 +4,7 @@ const wls: ShopCode = "wls";
 
 export const wlsProduct = {
   id: "132815",
-  title: "v vitalise energy drink 250ml Can 4pack",
+  title: "V Vitalise Energy Drink 250ml Can 4pack",
   image:
     "https://assets.woolworths.com.au/images/2010/132815.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
   productPageUrl:
@@ -21,7 +21,7 @@ export const wlsProduct = {
 
 export const wlsProductUnitless = {
   id: "907038",
-  title: "speight's gold medal beer ale Bottle 24x330mL",
+  title: "Speight's Gold Medal Beer Ale Bottle 24x330mL",
   image:
     "https://assets.woolworths.com.au/images/2010/907038.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
   productPageUrl:
@@ -38,7 +38,7 @@ export const wlsProductUnitless = {
 
 export const wlsProductPromoTag = {
   id: "98508",
-  title: "turks free range chicken breast skinless fillet 450g",
+  title: "Turks Free Range Chicken Breast Skinless Fillet 450g",
   image:
     "https://assets.woolworths.com.au/images/2010/98508.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
   productPageUrl:
@@ -59,7 +59,7 @@ export const wlsProductPromoTag = {
 
 export const wlsProductPromo = {
   id: "315692",
-  title: "v vitalise energy drink Single can 500mL",
+  title: "V Vitalise Energy Drink Single Can 500mL",
   image:
     "https://assets.woolworths.com.au/images/2010/315692.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
   productPageUrl:
@@ -80,7 +80,7 @@ export const wlsProductPromo = {
 
 export const wlsProductPromoUnitless = {
   id: "705958",
-  title: "speight's summit beer lager ultra low carb Bottle 24x330mL",
+  title: "Speight's Summit Beer Lager Ultra Low Carb Bottle 24x330mL",
   image:
     "https://assets.woolworths.com.au/images/2010/705958.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
   productPageUrl:
@@ -103,7 +103,7 @@ export const wlsProductPromoUnitless = {
 
 export const wlsProductMultibuy = {
   id: "344618",
-  title: "woolworths chicken whole Each 1.35kg",
+  title: "Woolworths Chicken Whole Each 1.35kg",
   image:
     "https://assets.woolworths.com.au/images/2010/344618.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
   productPageUrl:
@@ -126,7 +126,7 @@ export const wlsProductMultibuy = {
 
 export const wlsProductMultibuyLow = {
   id: "251463",
-  title: "woolworths NZ chicken mince breast 3% fat barn raised Tray 400g",
+  title: "Woolworths NZ Chicken Mince Breast 3% Fat Barn Raised Tray 400g",
   image:
     "https://assets.woolworths.com.au/images/2010/251463.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
   productPageUrl:
@@ -149,7 +149,7 @@ export const wlsProductMultibuyLow = {
 
 export const wlsProductMultibuyFresh = {
   id: "281082",
-  title: "fresh vegetable broccoli head",
+  title: "Fresh Vegetable Broccoli Head",
   image:
     "https://assets.woolworths.com.au/images/2010/281082.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
   productPageUrl:
@@ -172,7 +172,7 @@ export const wlsProductMultibuyFresh = {
 
 export const wlsProductMembersCard = {
   id: "139864",
-  title: "v vitalise energy drink guarana Single can 250mL",
+  title: "V Vitalise Energy Drink Guarana Single Can 250mL",
   image:
     "https://assets.woolworths.com.au/images/2010/139864.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
   productPageUrl:
@@ -197,7 +197,7 @@ export const wlsProductMembersCard = {
 
 export const wlsProductDisney = {
   id: "6014370",
-  title: "tegel free range quick cook chicken steaks chargrilled 4pk 400g",
+  title: "Tegel Free Range Quick Cook Chicken Steaks Chargrilled 4pk 400g",
   image:
     "https://assets.woolworths.com.au/images/2010/6014370.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
   productPageUrl:
@@ -216,7 +216,7 @@ export const wlsProductDisney = {
 
 export const wlsProductDisneyPromo = {
   id: "363271",
-  title: "tegel meal maker free range shredded roast chicken 100g 2 x 50g pks",
+  title: "Tegel Meal Maker Free Range Shredded Roast Chicken 100g 2 x 50g Pks",
   image:
     "https://assets.woolworths.com.au/images/2010/363271.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
   productPageUrl:

--- a/frontend/src/lib/test/fixtures/wls_actual.ts
+++ b/frontend/src/lib/test/fixtures/wls_actual.ts
@@ -2,7 +2,7 @@ export const wlsData: Product[] = [
   {
     id: "266023",
     supermarket: "wls",
-    title: "watties spaghetti in tomato sauce Cans 3pack",
+    title: "Watties Spaghetti In Tomato Sauce Cans 3pack",
     image:
       "https://assets.woolworths.com.au/images/2010/266023.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -20,7 +20,7 @@ export const wlsData: Product[] = [
   {
     id: "44571",
     supermarket: "wls",
-    title: "essentials pasta spaghetti 500g",
+    title: "Essentials Pasta Spaghetti 500g",
     image:
       "https://assets.woolworths.com.au/images/2010/44571.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -36,7 +36,7 @@ export const wlsData: Product[] = [
   {
     id: "4485",
     supermarket: "wls",
-    title: "watties spaghetti in tomato sauce Can 420g",
+    title: "Watties Spaghetti In Tomato Sauce Can 420g",
     image:
       "https://assets.woolworths.com.au/images/2010/4485.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -56,7 +56,7 @@ export const wlsData: Product[] = [
   {
     id: "727664",
     supermarket: "wls",
-    title: "diamond pasta spaghetti 500g",
+    title: "Diamond Pasta Spaghetti 500g",
     image:
       "https://assets.woolworths.com.au/images/2010/727664.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -72,7 +72,7 @@ export const wlsData: Product[] = [
   {
     id: "266027",
     supermarket: "wls",
-    title: "oak spaghetti in tomato sauce Can 420g",
+    title: "Oak Spaghetti In Tomato Sauce Can 420g",
     image:
       "https://assets.woolworths.com.au/images/2010/266027.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -88,7 +88,7 @@ export const wlsData: Product[] = [
   {
     id: "346830",
     supermarket: "wls",
-    title: "woolworths pasta spaghetti 500g",
+    title: "Woolworths Pasta Spaghetti 500g",
     image:
       "https://assets.woolworths.com.au/images/2010/346830.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -106,7 +106,7 @@ export const wlsData: Product[] = [
   {
     id: "74613",
     supermarket: "wls",
-    title: "la molisana pasta spaghetti 500g",
+    title: "La Molisana Pasta Spaghetti 500g",
     image:
       "https://assets.woolworths.com.au/images/2010/74613.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -127,7 +127,7 @@ export const wlsData: Product[] = [
   {
     id: "47681",
     supermarket: "wls",
-    title: "woolworths spaghetti in tomato sauce 420g",
+    title: "Woolworths Spaghetti In Tomato Sauce 420g",
     image:
       "https://assets.woolworths.com.au/images/2010/47681.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -148,7 +148,7 @@ export const wlsData: Product[] = [
   {
     id: "83763",
     supermarket: "wls",
-    title: "barilla pasta spaghetti no. 5 500g",
+    title: "Barilla Pasta Spaghetti No. 5 500g",
     image:
       "https://assets.woolworths.com.au/images/2010/83763.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -168,7 +168,7 @@ export const wlsData: Product[] = [
   {
     id: "6351",
     supermarket: "wls",
-    title: "watties spaghetti in tomato sauce Can 220g",
+    title: "Watties Spaghetti In Tomato Sauce Can 220g",
     image:
       "https://assets.woolworths.com.au/images/2010/6351.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -186,7 +186,7 @@ export const wlsData: Product[] = [
   {
     id: "661387",
     supermarket: "wls",
-    title: "watties spaghetti 50% less added sugar Can 420g",
+    title: "Watties Spaghetti 50% Less Added Sugar Can 420g",
     image:
       "https://assets.woolworths.com.au/images/2010/661387.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -206,7 +206,7 @@ export const wlsData: Product[] = [
   {
     id: "727658",
     supermarket: "wls",
-    title: "diamond pasta spaghetti wholemeal 500g",
+    title: "Diamond Pasta Spaghetti Wholemeal 500g",
     image:
       "https://assets.woolworths.com.au/images/2010/727658.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -222,7 +222,7 @@ export const wlsData: Product[] = [
   {
     id: "215450",
     supermarket: "wls",
-    title: "macro organic pasta spaghetti 500g",
+    title: "Macro Organic Pasta Spaghetti 500g",
     image:
       "https://assets.woolworths.com.au/images/2010/215450.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -240,7 +240,7 @@ export const wlsData: Product[] = [
   {
     id: "913866",
     supermarket: "wls",
-    title: "woolworths pasta long spaghetti Can 420g",
+    title: "Woolworths Pasta Long Spaghetti Can 420g",
     image:
       "https://assets.woolworths.com.au/images/2010/913866.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -261,7 +261,7 @@ export const wlsData: Product[] = [
   {
     id: "727453",
     supermarket: "wls",
-    title: "diamond pasta spaghetti gluten free 250g",
+    title: "Diamond Pasta Spaghetti Gluten Free 250g",
     image:
       "https://assets.woolworths.com.au/images/2010/727453.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -277,7 +277,7 @@ export const wlsData: Product[] = [
   {
     id: "6345",
     supermarket: "wls",
-    title: "watties spaghetti cheesy Can 420g",
+    title: "Watties Spaghetti Cheesy Can 420g",
     image:
       "https://assets.woolworths.com.au/images/2010/6345.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -297,7 +297,7 @@ export const wlsData: Product[] = [
   {
     id: "916794",
     supermarket: "wls",
-    title: "woolworths pasta cheesy spaghetti Can 420g",
+    title: "Woolworths Pasta Cheesy Spaghetti Can 420g",
     image:
       "https://assets.woolworths.com.au/images/2010/916794.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -318,7 +318,7 @@ export const wlsData: Product[] = [
   {
     id: "266029",
     supermarket: "wls",
-    title: "watties spaghetti with sausages Can 300g",
+    title: "Watties Spaghetti With Sausages Can 300g",
     image:
       "https://assets.woolworths.com.au/images/2010/266029.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -336,7 +336,7 @@ export const wlsData: Product[] = [
   {
     id: "757679",
     supermarket: "wls",
-    title: "macro organic spaghetti in tomato sauce Can 420g",
+    title: "Macro Organic Spaghetti In Tomato Sauce Can 420g",
     image:
       "https://assets.woolworths.com.au/images/2010/757679.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -352,7 +352,7 @@ export const wlsData: Product[] = [
   {
     id: "91105",
     supermarket: "wls",
-    title: "vetta smart pasta spaghetti 500g",
+    title: "Vetta Smart Pasta Spaghetti 500g",
     image:
       "https://assets.woolworths.com.au/images/2010/91105.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -368,7 +368,7 @@ export const wlsData: Product[] = [
   {
     id: "169421",
     supermarket: "wls",
-    title: "maggi recipe base spaghetti bolognese Sachet 26g",
+    title: "Maggi Recipe Base Spaghetti Bolognese Sachet 26g",
     image:
       "https://assets.woolworths.com.au/images/2010/169421.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -389,7 +389,7 @@ export const wlsData: Product[] = [
   {
     id: "620646",
     supermarket: "wls",
-    title: "barilla pasta spaghetti gluten free 340g",
+    title: "Barilla Pasta Spaghetti Gluten Free 340g",
     image:
       "https://assets.woolworths.com.au/images/2010/620646.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -405,7 +405,7 @@ export const wlsData: Product[] = [
   {
     id: "68343",
     supermarket: "wls",
-    title: "macro organic pasta spaghetti wholemeal 500g",
+    title: "Macro Organic Pasta Spaghetti Wholemeal 500g",
     image:
       "https://assets.woolworths.com.au/images/2010/68343.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -423,7 +423,7 @@ export const wlsData: Product[] = [
   {
     id: "912755",
     supermarket: "wls",
-    title: "woolworths spaghetti shortstrand 410g",
+    title: "Woolworths Spaghetti Shortstrand 410g",
     image:
       "https://assets.woolworths.com.au/images/2010/912755.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -444,7 +444,7 @@ export const wlsData: Product[] = [
   {
     id: "325330",
     supermarket: "wls",
-    title: "garofalo pasta spaghetti no. 9 500g",
+    title: "Garofalo Pasta Spaghetti No. 9 500g",
     image:
       "https://assets.woolworths.com.au/images/2010/325330.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -460,7 +460,7 @@ export const wlsData: Product[] = [
   {
     id: "449465",
     supermarket: "wls",
-    title: "vetta smart pasta protein spaghetti 375g",
+    title: "Vetta Smart Pasta Protein Spaghetti 375g",
     image:
       "https://assets.woolworths.com.au/images/2010/449465.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -476,7 +476,7 @@ export const wlsData: Product[] = [
   {
     id: "528208",
     supermarket: "wls",
-    title: "la molisana high protein pasta spaghetti 400g",
+    title: "La Molisana High Protein Pasta Spaghetti 400g",
     image:
       "https://assets.woolworths.com.au/images/2010/528208.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -492,7 +492,7 @@ export const wlsData: Product[] = [
   {
     id: "74798",
     supermarket: "wls",
-    title: "la molisana pasta wholewheat spaghetti 500g",
+    title: "La Molisana Pasta Wholewheat Spaghetti 500g",
     image:
       "https://assets.woolworths.com.au/images/2010/74798.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -513,7 +513,7 @@ export const wlsData: Product[] = [
   {
     id: "4407",
     supermarket: "wls",
-    title: "watties spaghetti with sausages Can 420g",
+    title: "Watties Spaghetti With Sausages Can 420g",
     image:
       "https://assets.woolworths.com.au/images/2010/4407.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -531,7 +531,7 @@ export const wlsData: Product[] = [
   {
     id: "4408",
     supermarket: "wls",
-    title: "watties spaghetti with meatballs Can 420g",
+    title: "Watties Spaghetti With Meatballs Can 420g",
     image:
       "https://assets.woolworths.com.au/images/2010/4408.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -549,7 +549,7 @@ export const wlsData: Product[] = [
   {
     id: "6013481",
     supermarket: "wls",
-    title: "delmaine chilled spaghetti 250g",
+    title: "Delmaine Chilled Spaghetti 250g",
     image:
       "https://assets.woolworths.com.au/images/2010/6013481.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -569,7 +569,7 @@ export const wlsData: Product[] = [
   {
     id: "290971",
     supermarket: "wls",
-    title: "san remo active plus pasta spaghetti 400g",
+    title: "San Remo Active Plus Pasta Spaghetti 400g",
     image:
       "https://assets.woolworths.com.au/images/2010/290971.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -585,7 +585,7 @@ export const wlsData: Product[] = [
   {
     id: "765841",
     supermarket: "wls",
-    title: "ceres organics pasta spaghetti quinoa 250g",
+    title: "Ceres Organics Pasta Spaghetti Quinoa 250g",
     image:
       "https://assets.woolworths.com.au/images/2010/765841.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -601,7 +601,7 @@ export const wlsData: Product[] = [
   {
     id: "68980",
     supermarket: "wls",
-    title: "macro organic pasta spaghetti gluten free 350g",
+    title: "Macro Organic Pasta Spaghetti Gluten Free 350g",
     image:
       "https://assets.woolworths.com.au/images/2010/68980.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -617,7 +617,7 @@ export const wlsData: Product[] = [
   {
     id: "418253",
     supermarket: "wls",
-    title: "woolworths chilled spaghetti bolognese 350g",
+    title: "Woolworths Chilled Spaghetti Bolognese 350g",
     image:
       "https://assets.woolworths.com.au/images/2010/418253.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -635,7 +635,7 @@ export const wlsData: Product[] = [
   {
     id: "279994",
     supermarket: "wls",
-    title: "woolworths pasta chilled spaghetti gluten free 250g",
+    title: "Woolworths Pasta Chilled Spaghetti Gluten Free 250g",
     image:
       "https://assets.woolworths.com.au/images/2010/279994.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -651,7 +651,7 @@ export const wlsData: Product[] = [
   {
     id: "770320",
     supermarket: "wls",
-    title: "woolworths diced tomatoes italian Can 400g",
+    title: "Woolworths Diced Tomatoes Italian Can 400g",
     image:
       "https://assets.woolworths.com.au/images/2010/770320.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -667,7 +667,7 @@ export const wlsData: Product[] = [
   {
     id: "700721",
     supermarket: "wls",
-    title: "san remo la pasta pasta & sauce macaroni cheese 160g",
+    title: "San Remo La Pasta Pasta & Sauce Macaroni Cheese 160g",
     image:
       "https://assets.woolworths.com.au/images/2010/700721.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -688,7 +688,7 @@ export const wlsData: Product[] = [
   {
     id: "270751",
     supermarket: "wls",
-    title: "watties flavoured tomatoes italian style Can 400g",
+    title: "Watties Flavoured Tomatoes Italian Style Can 400g",
     image:
       "https://assets.woolworths.com.au/images/2010/270751.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -706,7 +706,7 @@ export const wlsData: Product[] = [
   {
     id: "647705",
     supermarket: "wls",
-    title: "san remo gluten free brown rice pasta spaghetti 250g",
+    title: "San Remo Gluten Free Brown Rice Pasta Spaghetti 250g",
     image:
       "https://assets.woolworths.com.au/images/2010/647705.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -722,7 +722,7 @@ export const wlsData: Product[] = [
   {
     id: "265330",
     supermarket: "wls",
-    title: "wattie's very special soup italian minestrone canned 535g",
+    title: "Wattie's Very Special Soup Italian Minestrone Canned 535g",
     image:
       "https://assets.woolworths.com.au/images/2010/265330.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -743,7 +743,7 @@ export const wlsData: Product[] = [
   {
     id: "830129",
     supermarket: "wls",
-    title: "slendier slim prepacked meal spaghetti 400g",
+    title: "Slendier Slim Prepacked Meal Spaghetti 400g",
     image:
       "https://assets.woolworths.com.au/images/2010/830129.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -759,7 +759,7 @@ export const wlsData: Product[] = [
   {
     id: "79923",
     supermarket: "wls",
-    title: "continental classics recipe base spaghetti bolognese Pack 50g",
+    title: "Continental Classics Recipe Base Spaghetti Bolognese Pack 50g",
     image:
       "https://assets.woolworths.com.au/images/2010/79923.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -775,7 +775,7 @@ export const wlsData: Product[] = [
   {
     id: "232529",
     supermarket: "wls",
-    title: "culley's kitchen recipe base spaghetti bolognese Sachet 40g",
+    title: "Culley's Kitchen Recipe Base Spaghetti Bolognese Sachet 40g",
     image:
       "https://assets.woolworths.com.au/images/2010/232529.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -791,7 +791,7 @@ export const wlsData: Product[] = [
   {
     id: "257947",
     supermarket: "wls",
-    title: "mrs rogers organic recipe base spaghetti bolognaise 30g",
+    title: "Mrs Rogers Organic Recipe Base Spaghetti Bolognaise 30g",
     image:
       "https://assets.woolworths.com.au/images/2010/257947.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -807,7 +807,7 @@ export const wlsData: Product[] = [
   {
     id: "312185",
     supermarket: "wls",
-    title: "woolworths tomato sauce Refill 565g",
+    title: "Woolworths Tomato Sauce Refill 565g",
     image:
       "https://assets.woolworths.com.au/images/2010/312185.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -823,7 +823,7 @@ export const wlsData: Product[] = [
   {
     id: "279288",
     supermarket: "wls",
-    title: "wattie's pasta sauce original 420g",
+    title: "Wattie's Pasta Sauce Original 420g",
     image:
       "https://assets.woolworths.com.au/images/2010/279288.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:
@@ -841,7 +841,7 @@ export const wlsData: Product[] = [
   {
     id: "279301",
     supermarket: "wls",
-    title: "wattie's pasta sauce tomato & herb 420g",
+    title: "Wattie's Pasta Sauce Tomato & Herb 420g",
     image:
       "https://assets.woolworths.com.au/images/2010/279301.jpg?impolicy=wowcdxwbjbx&w=200&h=200",
     productPageUrl:


### PR DESCRIPTION
<!-- Description of task purpose -->
Woolworths products come in lowercase, but others use capitalised titles. Util has been added to turn strings to Title Case and applied to all three parsers for consistency.

Fixtures have been updated to match.

Project ticket: #176 

### Acceptance Criteria
- [x] Woolworths products have caps in their titles within the search response data

### Discoveries
<!-- Anything to note/for others' understanding -->

### Testing
<!-- Notes on how to manual test, evidence of added tests passing with 80% coverage etc -->

All tests (and test data) have been updated if affected by this change. Backend and Frontend tests all passing.

### Checklist
- [x] tests passing
- [X] applied relevant labels to PR ***(`chore`/`feat`/`fix` etc)***
- [ ] added screenshots/recordings ***(if applicable)***


### Screenshots/Recordings ***(optional)***
